### PR TITLE
Fix deprecation with DataFrames 0.15

### DIFF
--- a/src/context.jl
+++ b/src/context.jl
@@ -34,7 +34,7 @@ exceeds our `ctx.limit` we throw an `ImputeError`
 """
 function Base.ismissing(ctx::Context, x)
     missing = if isa(x, DataFrameRow)
-        any(entry -> ctx.missing(entry[2]), x)
+        any(entry -> ctx.missing(entry[2]), pairs(x))
     elseif isa(x, AbstractArray)
         any(ctx.missing, x)
     else


### PR DESCRIPTION
Iterating over a DataFrameRow is deprecated since DataFrames 0.15 and will yield values in 0.16. Starting from that version, ` any(ctx.missing, x)` will be enough.

DataFrames 0.16 (https://github.com/JuliaLang/METADATA.jl/pull/20229) cannot be tagged before this is merged and tagged.