### PR TITLE
feat: add hot deck imputation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,9 +19,10 @@ Tables = "0.2"
 julia = "1"
 
 [extras]
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 RDatasets = "ce6b1742-4840-55fa-b093-852dadbb1d8b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+
 
 [targets]
 test = ["DataFrames", "RDatasets", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
+
 [compat]
 DataFrames = ">= 0.16"
 IterTools = "1.2"
@@ -18,9 +19,9 @@ Tables = "0.2"
 julia = "1"
 
 [extras]
-DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 RDatasets = "ce6b1742-4840-55fa-b093-852dadbb1d8b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 
 [targets]
 test = ["DataFrames", "RDatasets", "Test"]

--- a/src/Impute.jl
+++ b/src/Impute.jl
@@ -7,6 +7,7 @@ using StatsBase
 using Tables: Tables, materializer, istable
 
 import Base.Iterators: drop
+import DataFrames: dropmissing
 
 export impute, impute!, chain, chain!, drop, drop!, interp, interp!, ImputeError
 
@@ -53,6 +54,7 @@ const global imputation_methods = (
     fill = Fill,
     locf = LOCF,
     nocb = NOCB,
+    hotdeck = HotDeck
 )
 
 include("deprecated.jl")
@@ -270,5 +272,38 @@ julia> Impute.nocb(df; vardim=1, context=Context(; limit=1.0))
 ```
 """ nocb
 
+@doc """
+    Impute.hotdeck(data; vardim=2, context=Context())
+
+Iterates backwards through the `data` and fills missing data with the next existing
+observation. See [HotDeck](@ref) for details.
+
+# Example
+```jldoctest
+julia> using DataFrames; using Impute: Impute, Context
+
+julia> df = DataFrame(:a => [1.0, 2.0, missing, missing, 5.0], :b => [1.1, 2.2, 3.3, missing, 5.5])
+5×2 DataFrames.DataFrame
+│ Row │ a        │ b        │
+│     │ Float64⍰ │ Float64⍰ │
+├─────┼──────────┼──────────┤
+│ 1   │ 1.0      │ 1.1      │
+│ 2   │ 2.0      │ 2.2      │
+│ 3   │ missing  │ 3.3      │
+│ 4   │ missing  │ missing  │
+│ 5   │ 5.0      │ 5.5      │
+
+julia> Impute.hotdeck(df; vardim = 1, context = Context(; limit = 1.0))
+5×2 DataFrames.DataFrame
+│ Row │ a        │ b        │
+│     │ Float64⍰ │ Float64⍰ │
+├─────┼──────────┼──────────┤
+│ 1   │ 1.0      │ 1.1      │
+│ 2   │ 2.0      │ 2.2      │
+│ 3   │ 5.0      │ 3.3      │
+│ 4   │ 5.0      │ 5.5      │
+│ 5   │ 5.0      │ 5.5      │
+```
+""" hotdeck
 
 end  # module

--- a/src/Impute.jl
+++ b/src/Impute.jl
@@ -275,8 +275,9 @@ julia> Impute.nocb(df; vardim=1, context=Context(; limit=1.0))
 @doc """
     Impute.hotdeck(data; vardim=2, context=Context())
 
-Iterates backwards through the `data` and fills missing data with the next existing
-observation. See [HotDeck](@ref) for details.
+Hot deck imputation is a method for imputing both continuous and categorical
+variables. Furthermore, it completes imputation while preserving the distributional 
+properties of the variables (e.g., mean, standard deviation). 
 
 # Example
 ```jldoctest

--- a/src/imputors.jl
+++ b/src/imputors.jl
@@ -127,6 +127,6 @@ function impute!(table, imp::Imputor)
 end
 
 
-for file in ("drop.jl", "locf.jl", "nocb.jl", "interp.jl", "fill.jl", "chain.jl")
+for file in ("drop.jl", "locf.jl", "nocb.jl", "interp.jl", "fill.jl", "chain.jl", "hotdeck.jl")
     include(joinpath("imputors", file))
 end

--- a/src/imputors/hotdeck.jl
+++ b/src/imputors/hotdeck.jl
@@ -42,8 +42,9 @@ HotDeck(; vardim = 2, context = Context()) = HotDeck(vardim, context)
 
 
 function impute!(data::AbstractVector, imp::HotDeck)
-    obs_values = collect(skipmissing(data))
-    imp.context() do c
+    
+    imp.context() do c 
+        obs_values = Impute.dropobs(data)
         for i = 1:lastindex(data)
             if ismissing(c, data[i])
                 data[i] = rand(obs_values)

--- a/src/imputors/hotdeck.jl
+++ b/src/imputors/hotdeck.jl
@@ -1,0 +1,55 @@
+@auto_hash_equals struct HotDeck <: Imputor
+   vardim::Int
+   context::AbstractContext
+end
+
+
+"""
+    HotDeck(; vardim = 2, context = Context())
+
+Hot deck imputation is a method for imputing both continuous and categorical
+variables. Furthermore, it completes imputation while preserving the distributional 
+properties of the variables (e.g., mean, standard deviation). 
+
+The basic idea is that for a given variable, `x`, with missing data, we randomly draw 
+from the observed values of `x` to impute the missing elements. Since the random draws
+from `x` for imputation are done in proportion to the frequency distribution of the values 
+in `x`, the univariate distributional properties are generally not impacted; this is true 
+for both categorical and continuous data.
+
+
+# Keyword Arguments
+* `vardim = 2::Int`: Specify the dimension for variables in matrix input data
+* `context::AbstractContext`: A context which keeps track of missing data
+  summary information
+
+# Example
+```jldoctest
+julia> using Impute: HotDeck, Context, impute
+
+julia> M = [1.0 2.0 missing missing 5.0; 1.1 2.2 3.3 missing 5.5]
+2×5 Array{Union{Missing, Float64},2}:
+ 1.0  2.0   missing  missing  5.0
+ 1.1  2.2  3.3       missing  5.5
+
+julia> impute(M, HotDeck(; vardim = 1, context = Context(; limit = 1.0)))
+2×5 Array{Union{Missing, Float64},2}:
+ 1.0  2.0  5.0  2.0  5.0
+ 1.1  2.2  3.3  3.3  5.5
+```
+"""
+HotDeck(; vardim = 2, context = Context()) = HotDeck(vardim, context)
+
+
+function impute!(data::AbstractVector, imp::HotDeck)
+    obs_values = collect(skipmissing(data))
+    imp.context() do c
+        for i = 1:lastindex(data)
+            if ismissing(c, data[i])
+                data[i] = rand(obs_values)
+            end
+        end
+
+        return data
+    end
+end


### PR DESCRIPTION
I've added the ability to use hot-deck imputation. This allows for the imputation of missing values while preserving the univariate-distributional properties of the variables being imputed.

I've written it to behave like the existing imputation methods. I've also written a few test, all of which are passing.

I'd also be interested in working on multiple imputation using chained equations—assuming there would be interest in that.