### PR TITLE
Add dims kwarg to impute!

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Invenia Technical Computing"]
 version = "0.2.0"
 
 [deps]
-AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"
 IterTools = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"

--- a/src/Impute.jl
+++ b/src/Impute.jl
@@ -88,10 +88,10 @@ for (f, v) in pairs(imputation_methods)
     f! = Symbol(f, :!)
 
     @eval begin
-        $f(data; kwargs...) = impute(data, $typename, kwargs...)
-        $f!(data; kwargs...) = impute!(data, $typename, kwargs...)
-        $f(; kwargs...) = data -> impute(data, $typename, kwargs...)
-        $f!(; kwargs...) = data -> impute!(data, $typename, kwargs...)
+        $f(data; kwargs...) = _impute(data, $typename, kwargs...)
+        $f!(data; kwargs...) = _impute!(data, $typename, kwargs...)
+        $f(; kwargs...) = data -> _impute(data, $typename, kwargs...)
+        $f!(; kwargs...) = data -> _impute!(data, $typename, kwargs...)
     end
 end
 

--- a/src/Impute.jl
+++ b/src/Impute.jl
@@ -88,10 +88,10 @@ for (f, v) in pairs(imputation_methods)
     f! = Symbol(f, :!)
 
     @eval begin
-        $f(data; kwargs...) = impute(data, $typename(; _extract_context_kwargs(kwargs...)...))
-        $f!(data; kwargs...) = impute!(data, $typename(; _extract_context_kwargs(kwargs...)...))
-        $f(; kwargs...) = data -> impute(data, $typename(; _extract_context_kwargs(kwargs...)...))
-        $f!(; kwargs...) = data -> impute!(data, $typename(; _extract_context_kwargs(kwargs...)...))
+        $f(data; kwargs...) = impute(data, $typename, kwargs...)
+        $f!(data; kwargs...) = impute!(data, $typename, kwargs...)
+        $f(; kwargs...) = data -> impute(data, $typename, kwargs...)
+        $f!(; kwargs...) = data -> impute!(data, $typename, kwargs...)
     end
 end
 

--- a/src/Impute.jl
+++ b/src/Impute.jl
@@ -1,6 +1,5 @@
 module Impute
 
-using AutoHashEquals
 using IterTools
 using Statistics
 using StatsBase
@@ -44,6 +43,33 @@ Base.showerror(io::IO, err::ImputeError) = println(io, "ImputeError: $(err.msg)"
 
 include("context.jl")
 include("imputors.jl")
+
+#=
+These default methods are required because @auto_hash_equals doesn't
+play nice with Base.@kwdef
+=#
+function Base.hash(imp::T, h::UInt) where T <: Union{Imputor, AbstractContext}
+    h = hash(Symbol(T), h)
+
+    for f in fieldnames(T)
+        h = hash(getfield(imp, f), h)
+    end
+
+    return h
+end
+
+function Base.:(==)(a::T, b::T) where T <: Union{Imputor, AbstractContext}
+    result = true
+
+    for f in fieldnames(T)
+        if !isequal(getfield(a, f), getfield(b, f))
+            result = false
+            break
+        end
+    end
+
+    return result
+end
 
 const global imputation_methods = (
     drop = DropObs,

--- a/src/Impute.jl
+++ b/src/Impute.jl
@@ -96,7 +96,7 @@ for (f, v) in pairs(imputation_methods)
 end
 
 @doc """
-    Impute.dropobs(data; vardim=2, context=Context())
+    Impute.dropobs(data; dims=1, context=Context())
 
 Removes missing observations from the `AbstractArray` or `Tables.table` provided.
 See [DropObs](@ref) for details.
@@ -116,7 +116,7 @@ julia> df = DataFrame(:a => [1.0, 2.0, missing, missing, 5.0], :b => [1.1, 2.2, 
 │ 4   │ missing  │ missing  │
 │ 5   │ 5.0      │ 5.5      │
 
-julia> Impute.dropobs(df; vardim=1, context=Context(; limit=1.0))
+julia> Impute.dropobs(df; dims=2, context=Context(; limit=1.0))
 3×2 DataFrames.DataFrame
 │ Row │ a       │ b       │
 │     │ Float64 │ Float64 │
@@ -128,7 +128,7 @@ julia> Impute.dropobs(df; vardim=1, context=Context(; limit=1.0))
 """ dropobs
 
 @doc """
-    Impute.dropvars(data; vardim=2, context=Context())
+    Impute.dropvars(data; dims=1, context=Context())
 
 Finds variables with too many missing values in a `AbstractMatrix` or `Tables.table` and
 removes them from the input data. See [DropVars](@ref) for details.
@@ -148,7 +148,7 @@ julia> df = DataFrame(:a => [1.0, 2.0, missing, missing, 5.0], :b => [1.1, 2.2, 
 │ 4   │ missing  │ missing  │
 │ 5   │ 5.0      │ 5.5      │
 
-julia> Impute.dropvars(df; vardim=1, context=Context(; limit=0.2))
+julia> Impute.dropvars(df; context=Context(; limit=0.2))
 5×1 DataFrames.DataFrame
 │ Row │ b        │
 │     │ Float64⍰ │
@@ -162,7 +162,7 @@ julia> Impute.dropvars(df; vardim=1, context=Context(; limit=0.2))
 """ dropvars
 
 @doc """
-    Impute.interp(data; vardim=2, context=Context())
+    Impute.interp(data; dims=1, context=Context())
 
 Performs linear interpolation between the nearest values in an vector.
 See [Interpolate](@ref) for details.
@@ -182,7 +182,7 @@ julia> df = DataFrame(:a => [1.0, 2.0, missing, missing, 5.0], :b => [1.1, 2.2, 
 │ 4   │ missing  │ missing  │
 │ 5   │ 5.0      │ 5.5      │
 
-julia> Impute.interp(df; vardim=1, context=Context(; limit=1.0))
+julia> Impute.interp(df; context=Context(; limit=1.0))
 5×2 DataFrames.DataFrame
 │ Row │ a        │ b        │
 │     │ Float64⍰ │ Float64⍰ │
@@ -196,7 +196,7 @@ julia> Impute.interp(df; vardim=1, context=Context(; limit=1.0))
 """ interp
 
 @doc """
-    Impute.fill(data; value=mean, vardim=2, context=Context())
+    Impute.fill(data; value=mean, dims=1, context=Context())
 
 Fills in the missing data with a specific value. See [Fill](@ref) for details.
 
@@ -215,7 +215,7 @@ julia> df = DataFrame(:a => [1.0, 2.0, missing, missing, 5.0], :b => [1.1, 2.2, 
 │ 4   │ missing  │ missing  │
 │ 5   │ 5.0      │ 5.5      │
 
-julia> Impute.fill(df; value=-1.0, vardim=1, context=Context(; limit=1.0))
+julia> Impute.fill(df; value=-1.0, context=Context(; limit=1.0))
 5×2 DataFrames.DataFrame
 │ Row │ a        │ b        │
 │     │ Float64⍰ │ Float64⍰ │
@@ -229,7 +229,7 @@ julia> Impute.fill(df; value=-1.0, vardim=1, context=Context(; limit=1.0))
 """ fill
 
 @doc """
-    Impute.locf(data; vardim=2, context=Context())
+    Impute.locf(data; dims=1, context=Context())
 
 Iterates forwards through the `data` and fills missing data with the last existing
 observation. See [LOCF](@ref) for details.
@@ -249,7 +249,7 @@ julia> df = DataFrame(:a => [1.0, 2.0, missing, missing, 5.0], :b => [1.1, 2.2, 
 │ 4   │ missing  │ missing  │
 │ 5   │ 5.0      │ 5.5      │
 
-julia> Impute.locf(df; vardim=1, context=Context(; limit=1.0))
+julia> Impute.locf(df; context=Context(; limit=1.0))
 5×2 DataFrames.DataFrame
 │ Row │ a        │ b        │
 │     │ Float64⍰ │ Float64⍰ │
@@ -263,7 +263,7 @@ julia> Impute.locf(df; vardim=1, context=Context(; limit=1.0))
 """ locf
 
 @doc """
-    Impute.nocb(data; vardim=2, context=Context())
+    Impute.nocb(data; dims=1, context=Context())
 
 Iterates backwards through the `data` and fills missing data with the next existing
 observation. See [LOCF](@ref) for details.
@@ -283,7 +283,7 @@ julia> df = DataFrame(:a => [1.0, 2.0, missing, missing, 5.0], :b => [1.1, 2.2, 
 │ 4   │ missing  │ missing  │
 │ 5   │ 5.0      │ 5.5      │
 
-julia> Impute.nocb(df; vardim=1, context=Context(; limit=1.0))
+julia> Impute.nocb(df; context=Context(; limit=1.0))
 5×2 DataFrames.DataFrame
 │ Row │ a        │ b        │
 │     │ Float64⍰ │ Float64⍰ │

--- a/src/context.jl
+++ b/src/context.jl
@@ -94,7 +94,7 @@ function Base.findnext(ctx::AbstractContext, data::AbstractVector, idx::Int)
     return findnext(x -> !ismissing(ctx, x), data, idx)
 end
 
-@auto_hash_equals mutable struct Context <: AbstractContext
+mutable struct Context <: AbstractContext
     num::Int
     count::Int
     limit::Float64
@@ -152,7 +152,7 @@ function complete(ctx::Context, data)
 end
 
 
-@auto_hash_equals mutable struct WeightedContext <: AbstractContext
+mutable struct WeightedContext <: AbstractContext
     num::Int
     s::Float64
     limit::Float64

--- a/src/imputors.jl
+++ b/src/imputors.jl
@@ -52,12 +52,13 @@ function splitkwargs(::Type{T}, kwargs...) where T <: Imputor
 end
 
 # Some utility methods for constructing imputors and imputing data in 1 call.
-function impute(data, t::Type{T}, kwargs...) where T <: Imputor
+# NOTE: This is only intended for internal use and is not part of the public API.
+function _impute(data, t::Type{T}, kwargs...) where T <: Imputor
     imp, rem = splitkwargs(t, _extract_context_kwargs(kwargs...)...)
     return impute(data, imp; rem...)
 end
 
-function impute!(data, t::Type{T}, kwargs...) where T <: Imputor
+function _impute!(data, t::Type{T}, kwargs...) where T <: Imputor
     imp, rem = splitkwargs(t, _extract_context_kwargs(kwargs...)...)
     return impute!(data, imp; rem...)
 end

--- a/src/imputors.jl
+++ b/src/imputors.jl
@@ -8,25 +8,25 @@ implement the `impute!(imp::<MyImputor>, data::AbstractVector)` method.
 abstract type Imputor end
 
 # A couple utility methods to avoid messing up var and obs dimensions
-obsdim(imp::Imputor) = imp.vardim == 1 ? 2 : 1
-vardim(imp::Imputor) = imp.vardim
+obsdim(dims) = dims
+vardim(dims) = dims == 1 ? 2 : 1
 
-function obswise(imp::Imputor, data::AbstractMatrix)
-    return (selectdim(data, obsdim(imp), i) for i in axes(data, obsdim(imp)))
+function obswise(data::AbstractMatrix; dims=1)
+    return (selectdim(data, obsdim(dims), i) for i in axes(data, obsdim(dims)))
 end
 
-function varwise(imp::Imputor, data::AbstractMatrix)
-    return (selectdim(data, vardim(imp), i) for i in axes(data, vardim(imp)))
+function varwise(data::AbstractMatrix; dims=2)
+    return (selectdim(data, vardim(dims), i) for i in axes(data, vardim(dims)))
 end
 
-function filterobs(f::Function, imp::Imputor, data::AbstractMatrix)
-    mask = [f(x) for x in obswise(imp, data)]
-    return imp.vardim == 1 ? data[:, mask] : data[mask, :]
+function filterobs(f::Function, data::AbstractMatrix; dims=1)
+    mask = [f(x) for x in obswise(data; dims=dims)]
+    return dims == 1 ? data[mask, :] : data[:, mask]
 end
 
-function filtervars(f::Function, imp::Imputor, data::AbstractMatrix)
-    mask = [f(x) for x in varwise(imp, data)]
-    return imp.vardim == 1 ? data[mask, :] : data[:, mask]
+function filtervars(f::Function, data::AbstractMatrix; dims=2)
+    mask = [f(x) for x in varwise(data; dims=dims)]
+    return dims == 1 ? data[:, mask] : data[mask, :]
 end
 
 """
@@ -51,7 +51,7 @@ function splitkwargs(::Type{T}, kwargs...) where T <: Imputor
     return (T(; kwdef...), rem)
 end
 
-# Some utility methods for constructing and imputing data in 1 call.
+# Some utility methods for constructing imputors and imputing data in 1 call.
 function impute(data, t::Type{T}, kwargs...) where T <: Imputor
     imp, rem = splitkwargs(t, _extract_context_kwargs(kwargs...)...)
     return impute(data, imp; rem...)
@@ -63,17 +63,20 @@ function impute!(data, t::Type{T}, kwargs...) where T <: Imputor
 end
 
 """
-    impute(data, imp::Imputor)
+    impute(data, imp::Imputor; kwargs...)
 
 Returns a new copy of the `data` with the missing data imputed by the imputor `imp`.
+
+# Keywords
+* `dims`: The dimension to impute along (e.g., observations dim)
 """
-function impute(data, imp::Imputor)
+function impute(data, imp::Imputor; kwargs...)
     # Call `deepcopy` because we can trust that it's available for all types.
-    return impute!(deepcopy(data), imp)
+    return impute!(deepcopy(data), imp; kwargs...)
 end
 
 """
-    impute!(data::AbstractMatrix, imp::Imputor)
+    impute!(data::AbstractMatrix, imp::Imputor; kwargs...)
 
 Impute the data in a matrix by imputing the values one variable at a time;
 if this is not the desired behaviour custom imputor methods should overload this method.
@@ -81,6 +84,9 @@ if this is not the desired behaviour custom imputor methods should overload this
 # Arguments
 * `data::AbstractMatrix`: the data to impute
 * `imp::Imputor`: the Imputor method to use
+
+# Keywords
+* `dims`: The dimension to impute along (e.g., observations dim)
 
 # Returns
 * `AbstractMatrix`: the input `data` with values imputed
@@ -94,14 +100,14 @@ julia> M = [1.0 2.0 missing missing 5.0; 1.1 2.2 3.3 missing 5.5]
  1.0  2.0   missing  missing  5.0
  1.1  2.2  3.3       missing  5.5
 
-julia> impute(M, Interpolate(; vardim=1, context=Context(; limit=1.0)))
+julia> impute(M, Interpolate(; context=Context(; limit=1.0)); dims=2)
 2×5 Array{Union{Missing, Float64},2}:
  1.0  2.0  3.0  4.0  5.0
  1.1  2.2  3.3  4.4  5.5
 ```
 """
-function impute!(data::AbstractMatrix, imp::Imputor)
-    for var in varwise(imp, data)
+function impute!(data::AbstractMatrix, imp::Imputor; dims=1)
+    for var in varwise(data; dims=dims)
         impute!(var, imp)
     end
     return data
@@ -134,7 +140,7 @@ julia> df = DataFrame(:a => [1.0, 2.0, missing, missing, 5.0], :b => [1.1, 2.2, 
 │ 4   │ missing  │ missing  │
 │ 5   │ 5.0      │ 5.5      │
 
-julia> impute(df, Interpolate(; vardim=1, context=Context(; limit=1.0)))
+julia> impute(df, Interpolate(; context=Context(; limit=1.0)))
 5×2 DataFrame
 │ Row │ a        │ b        │
 │     │ Float64⍰ │ Float64⍰ │

--- a/src/imputors/drop.jl
+++ b/src/imputors/drop.jl
@@ -1,8 +1,3 @@
-@auto_hash_equals struct DropObs <: Imputor
-    vardim::Int
-    context::AbstractContext
-end
-
 """
     DropObs(; vardim=2, context=Context)
 
@@ -28,6 +23,12 @@ julia> impute(M, DropObs(; vardim=1, context=Context(; limit=1.0)))
  1.1  2.2  5.5
 ```
 """
+struct DropObs <: Imputor
+    vardim::Int
+    context::AbstractContext
+end
+
+# TODO: Switch to using Base.@kwdef on 1.1
 DropObs(; vardim=2, context=Context()) = DropObs(vardim, context)
 
 function impute!(data::AbstractVector, imp::DropObs)
@@ -65,11 +66,6 @@ function impute!(table, imp::DropObs)
 end
 
 
-@auto_hash_equals struct DropVars <: Imputor
-    vardim::Int
-    context::AbstractContext
-end
-
 """
     DropVars(; vardim=2, context=Context())
 
@@ -96,6 +92,12 @@ julia> impute(M, DropVars(; vardim=1, context=Context(; limit=0.2)))
  1.1  2.2  3.3  missing  5.5
 ```
 """
+struct DropVars <: Imputor
+    vardim::Int
+    context::AbstractContext
+end
+
+# TODO: Switch to using Base.@kwdef on 1.1
 DropVars(; vardim=2, context=Context()) = DropVars(vardim, context)
 
 function impute!(data::AbstractMatrix, imp::DropVars)

--- a/src/imputors/drop.jl
+++ b/src/imputors/drop.jl
@@ -1,5 +1,5 @@
 """
-    DropObs(; ontext=Context)
+    DropObs(; context=Context)
 
 Removes missing observations from the `AbstractArray` or `Tables.table` provided.
 

--- a/src/imputors/drop.jl
+++ b/src/imputors/drop.jl
@@ -1,10 +1,9 @@
 """
-    DropObs(; vardim=2, context=Context)
+    DropObs(; ontext=Context)
 
 Removes missing observations from the `AbstractArray` or `Tables.table` provided.
 
 # Keyword Arguments
-* `vardim=2::Int`: Specify the dimension for variables in matrix input data
 * `context::AbstractContext=Context()`: A context which keeps track of missing data
   summary information
 
@@ -17,19 +16,18 @@ julia> M = [1.0 2.0 missing missing 5.0; 1.1 2.2 3.3 missing 5.5]
  1.0  2.0   missing  missing  5.0
  1.1  2.2  3.3       missing  5.5
 
-julia> impute(M, DropObs(; vardim=1, context=Context(; limit=1.0)))
+julia> impute(M, DropObs(; context=Context(; limit=1.0)); dims=2)
 2×3 Array{Union{Missing, Float64},2}:
  1.0  2.0  5.0
  1.1  2.2  5.5
 ```
 """
 struct DropObs <: Imputor
-    vardim::Int
     context::AbstractContext
 end
 
 # TODO: Switch to using Base.@kwdef on 1.1
-DropObs(; vardim=2, context=Context()) = DropObs(vardim, context)
+DropObs(; context=Context()) = DropObs(context)
 
 function impute!(data::AbstractVector, imp::DropObs)
     imp.context() do c
@@ -37,9 +35,9 @@ function impute!(data::AbstractVector, imp::DropObs)
     end
 end
 
-function impute!(data::AbstractMatrix, imp::DropObs)
+function impute!(data::AbstractMatrix, imp::DropObs; dims=1)
     imp.context() do c
-        return filterobs(imp, data) do obs
+        return filterobs(data; dims=dims) do obs
             !ismissing(c, obs)
         end
     end
@@ -67,14 +65,13 @@ end
 
 
 """
-    DropVars(; vardim=2, context=Context())
+    DropVars(; context=Context())
 
 
 Finds variables with too many missing values in a `AbstractMatrix` or `Tables.table` and
 removes them from the input data.
 
 # Keyword Arguments
-* `vardim=2::Int`: Specify the dimension for variables in matrix input data
 * `context::AbstractContext`: A context which keeps track of missing data
   summary information
 
@@ -87,21 +84,20 @@ julia> M = [1.0 2.0 missing missing 5.0; 1.1 2.2 3.3 missing 5.5]
  1.0  2.0   missing  missing  5.0
  1.1  2.2  3.3       missing  5.5
 
-julia> impute(M, DropVars(; vardim=1, context=Context(; limit=0.2)))
+julia> impute(M, DropVars(; context=Context(; limit=0.2)); dims=2)
 1×5 Array{Union{Missing, Float64},2}:
  1.1  2.2  3.3  missing  5.5
 ```
 """
 struct DropVars <: Imputor
-    vardim::Int
     context::AbstractContext
 end
 
 # TODO: Switch to using Base.@kwdef on 1.1
-DropVars(; vardim=2, context=Context()) = DropVars(vardim, context)
+DropVars(; context=Context()) = DropVars(context)
 
-function impute!(data::AbstractMatrix, imp::DropVars)
-    return filtervars(imp, data) do var
+function impute!(data::AbstractMatrix, imp::DropVars; dims=1)
+    return filtervars(data; dims=dims) do var
         try
             imp.context() do c
                 for x in var

--- a/src/imputors/fill.jl
+++ b/src/imputors/fill.jl
@@ -1,9 +1,3 @@
-@auto_hash_equals struct Fill{T} <: Imputor
-    value::T
-    vardim::Int
-    context::AbstractContext
-end
-
 """
     Fill(; value=mean, vardim=2, context=Context())
 
@@ -33,6 +27,13 @@ julia> impute(M, Fill(; vardim=1, context=Context(; limit=1.0)))
  1.1  2.2  3.3      3.025    5.5
 ```
 """
+struct Fill{T} <: Imputor
+    value::T
+    vardim::Int
+    context::AbstractContext
+end
+
+# TODO: Switch to using Base.@kwdef on 1.1
 Fill(; value=mean, vardim=2, context=Context()) = Fill(value, vardim, context)
 
 function impute!(data::AbstractVector, imp::Fill)

--- a/src/imputors/fill.jl
+++ b/src/imputors/fill.jl
@@ -1,5 +1,5 @@
 """
-    Fill(; value=mean, vardim=2, context=Context())
+    Fill(; value=mean, context=Context())
 
 Fills in the missing data with a specific value.
 The current implementation is univariate, so each variable in a table or matrix will
@@ -8,7 +8,6 @@ be handled independently.
 # Keyword Arguments
 * `value::Any`: A scalar or a function that returns a scalar if
   passed the data with missing data removed (e.g, `mean`)
-* `vardim=2::Int`: Specify the dimension for variables in matrix input data
 * `context::AbstractContext`: A context which keeps track of missing data
   summary information
 
@@ -21,7 +20,7 @@ julia> M = [1.0 2.0 missing missing 5.0; 1.1 2.2 3.3 missing 5.5]
  1.0  2.0   missing  missing  5.0
  1.1  2.2  3.3       missing  5.5
 
-julia> impute(M, Fill(; vardim=1, context=Context(; limit=1.0)))
+julia> impute(M, Fill(; context=Context(; limit=1.0)); dims=2)
 2×5 Array{Union{Missing, Float64},2}:
  1.0  2.0  2.66667  2.66667  5.0
  1.1  2.2  3.3      3.025    5.5
@@ -29,12 +28,11 @@ julia> impute(M, Fill(; vardim=1, context=Context(; limit=1.0)))
 """
 struct Fill{T} <: Imputor
     value::T
-    vardim::Int
     context::AbstractContext
 end
 
 # TODO: Switch to using Base.@kwdef on 1.1
-Fill(; value=mean, vardim=2, context=Context()) = Fill(value, vardim, context)
+Fill(; value=mean, context=Context()) = Fill(value, context)
 
 function impute!(data::AbstractVector, imp::Fill)
     imp.context() do c

--- a/src/imputors/interp.jl
+++ b/src/imputors/interp.jl
@@ -1,8 +1,3 @@
-@auto_hash_equals struct Interpolate <: Imputor
-    vardim::Int
-    context::AbstractContext
-end
-
 """
     Interpolate(; vardim=2, context=Context())
 
@@ -34,6 +29,12 @@ julia> impute(M, Interpolate(; vardim=1, context=Context(; limit=1.0)))
  1.1  2.2  3.3  4.4  5.5
 ```
 """
+struct Interpolate <: Imputor
+    vardim::Int
+    context::AbstractContext
+end
+
+# TODO: Switch to using Base.@kwdef on 1.1
 Interpolate(; vardim=2, context=Context()) = Interpolate(vardim, context)
 
 function impute!(data::AbstractVector{<:Union{T, Missing}}, imp::Interpolate) where T

--- a/src/imputors/interp.jl
+++ b/src/imputors/interp.jl
@@ -1,5 +1,5 @@
 """
-    Interpolate(; vardim=2, context=Context())
+    Interpolate(; context=Context())
 
 Performs linear interpolation between the nearest values in an vector.
 The current implementation is univariate, so each variable in a table or matrix will
@@ -10,7 +10,6 @@ are no existing values on both sides. As a result, this method does not guarante
 that all missing values will be imputed.
 
 # Keyword Arguments
-* `vardim=2::Int`: Specify the dimension for variables in matrix input data
 * `context::AbstractContext`: A context which keeps track of missing data
   summary information
 
@@ -23,19 +22,18 @@ julia> M = [1.0 2.0 missing missing 5.0; 1.1 2.2 3.3 missing 5.5]
  1.0  2.0   missing  missing  5.0
  1.1  2.2  3.3       missing  5.5
 
-julia> impute(M, Interpolate(; vardim=1, context=Context(; limit=1.0)))
+julia> impute(M, Interpolate(; context=Context(; limit=1.0)); dims=2)
 2×5 Array{Union{Missing, Float64},2}:
  1.0  2.0  3.0  4.0  5.0
  1.1  2.2  3.3  4.4  5.5
 ```
 """
 struct Interpolate <: Imputor
-    vardim::Int
     context::AbstractContext
 end
 
 # TODO: Switch to using Base.@kwdef on 1.1
-Interpolate(; vardim=2, context=Context()) = Interpolate(vardim, context)
+Interpolate(; context=Context()) = Interpolate(context)
 
 function impute!(data::AbstractVector{<:Union{T, Missing}}, imp::Interpolate) where T
     imp.context() do c

--- a/src/imputors/locf.jl
+++ b/src/imputors/locf.jl
@@ -1,5 +1,5 @@
 """
-    LOCF(; vardim=2, context=Context())
+    LOCF(; context=Context())
 
 Last observation carried forward (LOCF) iterates forwards through the `data` and fills
 missing data with the last existing observation. The current implementation is univariate,
@@ -13,7 +13,6 @@ existing observation to carry forward. As a result, this method does not guarant
 that all missing values will be imputed.
 
 # Keyword Arguments
-* `vardim=2::Int`: Specify the dimension for variables in matrix input data
 * `context::AbstractContext`: A context which keeps track of missing data
   summary information
 
@@ -26,19 +25,18 @@ julia> M = [1.0 2.0 missing missing 5.0; 1.1 2.2 3.3 missing 5.5]
  1.0  2.0   missing  missing  5.0
  1.1  2.2  3.3       missing  5.5
 
-julia> impute(M, LOCF(; vardim=1, context=Context(; limit=1.0)))
+julia> impute(M, LOCF(; context=Context(; limit=1.0)); dims=2)
 2×5 Array{Union{Missing, Float64},2}:
  1.0  2.0  2.0  2.0  5.0
  1.1  2.2  3.3  3.3  5.5
 ```
 """
 struct LOCF <: Imputor
-    vardim::Int
     context::AbstractContext
 end
 
 # TODO: Switch to using Base.@kwdef on 1.1
-LOCF(; vardim=2, context=Context()) = LOCF(vardim, context)
+LOCF(; context=Context()) = LOCF(context)
 
 function impute!(data::AbstractVector, imp::LOCF)
     imp.context() do c

--- a/src/imputors/locf.jl
+++ b/src/imputors/locf.jl
@@ -1,8 +1,3 @@
-@auto_hash_equals struct LOCF <: Imputor
-    vardim::Int
-    context::AbstractContext
-end
-
 """
     LOCF(; vardim=2, context=Context())
 
@@ -37,6 +32,12 @@ julia> impute(M, LOCF(; vardim=1, context=Context(; limit=1.0)))
  1.1  2.2  3.3  3.3  5.5
 ```
 """
+struct LOCF <: Imputor
+    vardim::Int
+    context::AbstractContext
+end
+
+# TODO: Switch to using Base.@kwdef on 1.1
 LOCF(; vardim=2, context=Context()) = LOCF(vardim, context)
 
 function impute!(data::AbstractVector, imp::LOCF)

--- a/src/imputors/nocb.jl
+++ b/src/imputors/nocb.jl
@@ -1,5 +1,5 @@
 """
-    NOCB(; vardim=2, context=Context())
+    NOCB(; context=Context())
 
 Next observation carried backward (NOCB) iterates backwards through the `data` and fills
 missing data with the next existing observation.
@@ -12,7 +12,6 @@ existing observation to carry backward. As a result, this method does not guaran
 that all missing values will be imputed.
 
 # Keyword Arguments
-* `vardim=2::Int`: Specify the dimension for variables in matrix input data
 * `context::AbstractContext`: A context which keeps track of missing data
   summary information
 
@@ -25,19 +24,18 @@ julia> M = [1.0 2.0 missing missing 5.0; 1.1 2.2 3.3 missing 5.5]
  1.0  2.0   missing  missing  5.0
  1.1  2.2  3.3       missing  5.5
 
-julia> impute(M, NOCB(; vardim=1, context=Context(; limit=1.0)))
+julia> impute(M, NOCB(; context=Context(; limit=1.0)); dims=2)
 2×5 Array{Union{Missing, Float64},2}:
  1.0  2.0  5.0  5.0  5.0
  1.1  2.2  3.3  5.5  5.5
 ```
 """
 struct NOCB <: Imputor
-    vardim::Int
     context::AbstractContext
 end
 
 # TODO: Switch to using Base.@kwdef on 1.1
-NOCB(; vardim=2, context=Context()) = NOCB(vardim, context)
+NOCB(; context=Context()) = NOCB(context)
 
 function impute!(data::AbstractVector, imp::NOCB)
     imp.context() do c

--- a/src/imputors/nocb.jl
+++ b/src/imputors/nocb.jl
@@ -1,8 +1,3 @@
-@auto_hash_equals struct NOCB <: Imputor
-    vardim::Int
-    context::AbstractContext
-end
-
 """
     NOCB(; vardim=2, context=Context())
 
@@ -36,6 +31,12 @@ julia> impute(M, NOCB(; vardim=1, context=Context(; limit=1.0)))
  1.1  2.2  3.3  5.5  5.5
 ```
 """
+struct NOCB <: Imputor
+    vardim::Int
+    context::AbstractContext
+end
+
+# TODO: Switch to using Base.@kwdef on 1.1
 NOCB(; vardim=2, context=Context()) = NOCB(vardim, context)
 
 function impute!(data::AbstractVector, imp::NOCB)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -54,7 +54,7 @@ import Impute:
 
                 @test isequal(result, expected)
                 @test isequal(result, Impute.dropvars(m; context=ctx))
-                @test isequal(result', Impute.dropvars(m'; vardim=1, context=ctx))
+                @test isequal(result', Impute.dropvars(m'; dims=2, context=ctx))
 
                 Impute.dropvars!(m; context=ctx)
                 # The mutating test is broken because we need to making a copy of
@@ -207,10 +207,10 @@ import Impute:
         @testset "Drop" begin
             result = impute(data, DropObs(; context=ctx))
             @test size(result, 1) == 4
-            @test result == Impute.dropobs(data; context=ctx)
+            @test result == Impute.dropobs(data; context=ctx, dims=1)
 
             @test result == expected
-            @test Impute.dropobs(data'; vardim=1, context=ctx) == expected'
+            @test Impute.dropobs(data'; dims=2, context=ctx) == expected'
         end
 
         @testset "Fill" begin
@@ -319,28 +319,26 @@ import Impute:
     end
 
     @testset "Utils" begin
-        drop_dim1 = DropObs(; vardim=1)
-        drop_dim2 = DropObs(; vardim=2)
         M = [1.0 2.0 3.0 4.0 5.0; 1.1 2.2 3.3 4.4 5.5]
 
         @testset "obswise" begin
-            @test map(sum, Impute.obswise(drop_dim1, M)) == [2.1, 4.2, 6.3, 8.4, 10.5]
-            @test map(sum, Impute.obswise(drop_dim2, M)) == [15, 16.5]
+            @test map(sum, Impute.obswise(M; dims=2)) == [2.1, 4.2, 6.3, 8.4, 10.5]
+            @test map(sum, Impute.obswise(M; dims=1)) == [15, 16.5]
         end
 
         @testset "varwise" begin
-            @test map(sum, Impute.varwise(drop_dim1, M)) == [15, 16.5]
-            @test map(sum, Impute.varwise(drop_dim2, M)) == [2.1, 4.2, 6.3, 8.4, 10.5]
+            @test map(sum, Impute.varwise(M; dims=2)) == [15, 16.5]
+            @test map(sum, Impute.varwise(M; dims=1)) == [2.1, 4.2, 6.3, 8.4, 10.5]
         end
 
         @testset "filterobs" begin
-            @test Impute.filterobs(x -> sum(x) > 5.0, drop_dim1, M) == M[:, 3:5]
-            @test Impute.filterobs(x -> sum(x) > 15.0, drop_dim2, M) == M[[false, true], :]
+            @test Impute.filterobs(x -> sum(x) > 5.0, M; dims=2) == M[:, 3:5]
+            @test Impute.filterobs(x -> sum(x) > 15.0, M; dims=1) == M[[false, true], :]
         end
 
         @testset "filtervars" begin
-            @test Impute.filtervars(x -> sum(x) > 15.0, drop_dim1, M) == M[[false, true], :]
-            @test Impute.filtervars(x -> sum(x) > 5.0, drop_dim2, M) == M[:, 3:5]
+            @test Impute.filtervars(x -> sum(x) > 15.0, M; dims=2) == M[[false, true], :]
+            @test Impute.filtervars(x -> sum(x) > 5.0, M; dims=1) == M[:, 3:5]
         end
     end
 


### PR DESCRIPTION
Closes #32 

- Moved vardim field from imputors to impute! call
- Renamed vardim to dims (e.g., obsdim)
- Add a splitkwargs hack which will identify kwargs for the Imputor constructor and return the remaining kwargs that should be passed to the impute call.