### PR TITLE
Add more tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,9 @@ authors = ["Invenia Technical Computing"]
 version = "0.2.0"
 
 [deps]
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 IterTools = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
+Missings = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"

--- a/Project.toml
+++ b/Project.toml
@@ -4,9 +4,7 @@ authors = ["Invenia Technical Computing"]
 version = "0.2.0"
 
 [deps]
-DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 IterTools = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
-Missings = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
@@ -19,9 +17,11 @@ Tables = "0.2"
 julia = "1"
 
 [extras]
+AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 RDatasets = "ce6b1742-4840-55fa-b093-852dadbb1d8b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DataFrames", "RDatasets", "Test"]
+test = ["AxisArrays", "DataFrames", "Dates", "RDatasets", "Test"]

--- a/README.md
+++ b/README.md
@@ -115,3 +115,6 @@ julia> Impute.interp(df) |> Impute.locf() |> Impute.nocb()
 
 - Your approach should depend on the properties of you data (e.g., [MCAR, MAR, MNAR](https://en.wikipedia.org/wiki/Missing_data#Types_of_missing_data)).
 - In-place calls aren't guaranteedto mutate the original data, but it will try avoid copying if possible.
+  In the future, it may be possible to detect whether in-place operations are permitted on an array or table using traits:
+    - https://github.com/JuliaData/Tables.jl/issues/116
+    - https://github.com/JuliaDiffEq/ArrayInterface.jl/issues/22

--- a/README.md
+++ b/README.md
@@ -111,4 +111,7 @@ julia> Impute.interp(df) |> Impute.locf() |> Impute.nocb()
 │ 469 │ -247.6   │ -180.7   │ -70.9   │ 33.7     │ 114.8    │ 222.5    │
 ```
 
-**Warning**: Your approach should depend on the properties of you data (e.g., [MCAR, MAR, MNAR](https://en.wikipedia.org/wiki/Missing_data#Types_of_missing_data)).
+**Warning:**
+
+- Your approach should depend on the properties of you data (e.g., [MCAR, MAR, MNAR](https://en.wikipedia.org/wiki/Missing_data#Types_of_missing_data)).
+- In-place calls aren't guaranteedto mutate the original data, but it will try avoid copying if possible.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -52,4 +52,7 @@ Finally, we can chain multiple simple methods together to give a complete datase
 Impute.interp(df) |> Impute.locf() |> Impute.nocb()
 ```
 
-Warning: Your approach should depend on the properties of you data (e.g., [MCAR, MAR, MNAR](https://en.wikipedia.org/wiki/Missing_data#Types_of_missing_data)).
+**Warning:**
+
+- Your approach should depend on the properties of you data (e.g., [MCAR, MAR, MNAR](https://en.wikipedia.org/wiki/Missing_data#Types_of_missing_data)).
+- In-place calls aren't guaranteedto mutate the original data, but it will try avoid copying if possible.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -56,3 +56,6 @@ Impute.interp(df) |> Impute.locf() |> Impute.nocb()
 
 - Your approach should depend on the properties of you data (e.g., [MCAR, MAR, MNAR](https://en.wikipedia.org/wiki/Missing_data#Types_of_missing_data)).
 - In-place calls aren't guaranteedto mutate the original data, but it will try avoid copying if possible.
+  In the future, it may be possible to detect whether in-place operations are permitted on an array or table using traits:
+    - https://github.com/JuliaData/Tables.jl/issues/116
+    - https://github.com/JuliaDiffEq/ArrayInterface.jl/issues/22

--- a/src/imputors/fill.jl
+++ b/src/imputors/fill.jl
@@ -38,7 +38,7 @@ function impute!(data::AbstractVector, imp::Fill)
     imp.context() do c
         fill_val = if isa(imp.value, Function)
             # Call `deepcopy` because we can trust that it's available for all types.
-            imp.value(Impute.drop(deepcopy(data); context=c))
+            imp.value(Impute.drop(data; context=c))
         else
             imp.value
         end

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -12,9 +12,8 @@
 
         # Mutating method
         a2 = copy(a)
-        a2_ = Impute.drop!(a2; limit=0.2)
-        @test_broken a2 == expected
-        @test a2_ == expected
+        Impute.drop!(a2; limit=0.2)
+        @test a2 == expected
     end
 
     @testset "Interpolate" begin

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -12,8 +12,9 @@
 
         # Mutating method
         a2 = copy(a)
-        Impute.drop!(a2; limit=0.2)
-        @test a2 == expected
+        a2_ = Impute.drop!(a2; limit=0.2)
+        @test_broken a2 == expected
+        @test a2_ == expected
     end
 
     @testset "Interpolate" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,9 +60,8 @@ import Impute:
                 @test result == Impute.dropobs(a; context=ctx)
 
                 a2 = deepcopy(a)
-                a2_ = Impute.dropobs!(a2; context=ctx)
-                @test_broken a2 == expected
-                @test a2_ == expected
+                Impute.dropobs!(a2; context=ctx)
+                @test a2 == expected
             end
 
             @testset "Matrix" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,8 +60,9 @@ import Impute:
                 @test result == Impute.dropobs(a; context=ctx)
 
                 a2 = deepcopy(a)
-                Impute.dropobs!(a2; context=ctx)
-                @test a2 == expected
+                a2_ = Impute.dropobs!(a2; context=ctx)
+                @test_broken a2 == expected
+                @test a2_ == expected
             end
 
             @testset "Matrix" begin
@@ -440,8 +441,8 @@ import Impute:
 
         @test Impute.dropobs(data1; context=ctx1) == dropmissing(data1)
 
-        result1 = Impute.interp(data1; context=ctx1) |> Impute.dropobs!()
-        result2 = Impute.interp(data2; context=ctx2) |> Impute.dropobs!(; context=ctx2)
+        result1 = Impute.interp(data1; context=ctx1) |> Impute.dropobs()
+        result2 = Impute.interp(data2; context=ctx2) |> Impute.dropobs(; context=ctx2)
 
         @test result1 == result2
     end


### PR DESCRIPTION
Closes #30 and #27.

NOTE: Since dropobs requires that `parent(data) === data` you may find unexpected behaviour when working with wrapper array types where it'll return the parent type rather than the wrapper type. I'm not sure if there is a good way around this since `setparent!` isn't a thing.