### PR TITLE
ismissing -> ismissing!

### DIFF
--- a/src/context.jl
+++ b/src/context.jl
@@ -21,10 +21,10 @@ abstract type AbstractContext end
 Base.copy(ctx::T) where {T <: AbstractContext} = T(fieldvalues(ctx)...)
 
 """
-    ismissing(ctx::AbstractContext, x) -> Bool
+    ismissing!(ctx::AbstractContext, x) -> Bool
 
 Uses `ctx.is_missing` to determine if x is missing. If x is a `NamedTuple` or an `AbstractArray`
-then `ismissing` will return true if `ctx.is_missing` returns true for any element.
+then `ismissing!` will return true if `ctx.is_missing` returns true for any element.
 The ctx.count is increased whenever whenever we return true and if `ctx.count / ctx.num`
 exceeds our `ctx.limit` we throw an `ImputeError`
 
@@ -32,7 +32,7 @@ exceeds our `ctx.limit` we throw an `ImputeError`
 * `ctx::Context`: the contextual information about missing information.
 * `x`: the value to check (may be an single values, abstract array or row)
 """
-function Base.ismissing(ctx::AbstractContext, x)
+function ismissing!(ctx::AbstractContext, x)
     was_missing = if isa(x, NamedTuple)
         any(ctx.is_missing, Tuple(x))
     elseif isa(x, AbstractArray)
@@ -52,14 +52,14 @@ end
 Returns the first non-missing index in `data`.
 
 # Arguments
-* `ctx::AbstractContext`: the context to pass into `ismissing`
+* `ctx::AbstractContext`: the context to pass into `ismissing!`
 * `data::AbstractVector`: the data array to search
 
 # Returns
 * `Int`: the first index in `data` that isn't missing
 """
 function Base.findfirst(ctx::AbstractContext, data::AbstractVector)
-    return findfirst(x -> !ismissing(ctx, x), data)
+    return findfirst(x -> !ismissing!(ctx, x), data)
 end
 
 """
@@ -68,14 +68,14 @@ end
 Returns the last non-missing index in `data`.
 
 # Arguments
-* `ctx::AbstractContext`: the context to pass into `ismissing`
+* `ctx::AbstractContext`: the context to pass into `ismissing!`
 * `data::AbstractVector`: the data array to search
 
 # Returns
 * `Int`: the last index in `data` that isn't missing
 """
 function Base.findlast(ctx::AbstractContext, data::AbstractVector)
-    return findlast(x -> !ismissing(ctx, x), data)
+    return findlast(x -> !ismissing!(ctx, x), data)
 end
 
 """
@@ -84,14 +84,14 @@ end
 Returns the next non-missing index in `data`.
 
 # Arguments
-* `ctx::AbstractContext`: the context to pass into `ismissing`
+* `ctx::AbstractContext`: the context to pass into `ismissing!`
 * `data::AbstractVector`: the data array to search
 
 # Returns
 * `Int`: the next index in `data` that isn't missing
 """
 function Base.findnext(ctx::AbstractContext, data::AbstractVector, idx::Int)
-    return findnext(x -> !ismissing(ctx, x), data, idx)
+    return findnext(x -> !ismissing!(ctx, x), data, idx)
 end
 
 mutable struct Context <: AbstractContext

--- a/src/imputors/drop.jl
+++ b/src/imputors/drop.jl
@@ -31,14 +31,14 @@ DropObs(; context=Context()) = DropObs(context)
 
 function impute!(data::AbstractVector, imp::DropObs)
     imp.context() do c
-        filter!(x -> !ismissing(c, x), data)
+        filter!(x -> !ismissing!(c, x), data)
     end
 end
 
 function impute!(data::AbstractMatrix, imp::DropObs; dims=1)
     imp.context() do c
         return filterobs(data; dims=dims) do obs
-            !ismissing(c, obs)
+            !ismissing!(c, obs)
         end
     end
 end
@@ -55,7 +55,7 @@ function impute!(table, imp::DropObs)
         # Unfortunately, we'll need to construct a new table
         # since Tables.rows is just an iterator
         filtered = Iterators.filter(rows) do r
-            !any(x -> ismissing(c, x), propertyvalues(r))
+            !any(x -> ismissing!(c, x), propertyvalues(r))
         end
 
         table = materializer(table)(filtered)
@@ -101,7 +101,7 @@ function impute!(data::AbstractMatrix, imp::DropVars; dims=1)
         try
             imp.context() do c
                 for x in var
-                    ismissing(c, x)
+                    ismissing!(c, x)
                 end
             end
             return true
@@ -124,7 +124,7 @@ function impute!(table, imp::DropVars)
             imp.context() do c
                 col = getproperty(cols, cname)
                 for i in eachindex(col)
-                    ismissing(c, col[i])
+                    ismissing!(c, col[i])
                 end
             end
             return true

--- a/src/imputors/fill.jl
+++ b/src/imputors/fill.jl
@@ -44,7 +44,7 @@ function impute!(data::AbstractVector, imp::Fill)
         end
 
         for i in eachindex(data)
-            if ismissing(c, data[i])
+            if ismissing!(c, data[i])
                 data[i] = fill_val
             end
         end

--- a/src/imputors/interp.jl
+++ b/src/imputors/interp.jl
@@ -40,7 +40,7 @@ function impute!(data::AbstractVector{<:Union{T, Missing}}, imp::Interpolate) wh
         i = findfirst(c, data) + 1
 
         while i < lastindex(data)
-            if ismissing(c, data[i])
+            if ismissing!(c, data[i])
                 prev_idx = i - 1
                 next_idx = findnext(c, data, i + 1)
 

--- a/src/imputors/locf.jl
+++ b/src/imputors/locf.jl
@@ -42,7 +42,7 @@ function impute!(data::AbstractVector, imp::LOCF)
     imp.context() do c
         start_idx = findfirst(c, data) + 1
         for i in start_idx:lastindex(data)
-            if ismissing(c, data[i])
+            if ismissing!(c, data[i])
                 data[i] = data[i-1]
             end
         end

--- a/src/imputors/nocb.jl
+++ b/src/imputors/nocb.jl
@@ -41,7 +41,7 @@ function impute!(data::AbstractVector, imp::NOCB)
     imp.context() do c
         end_idx = findlast(c, data) - 1
         for i in end_idx:-1:firstindex(data)
-            if ismissing(c, data[i])
+            if ismissing!(c, data[i])
                 data[i] = data[i+1]
             end
         end


### PR DESCRIPTION
Rename `ismissing(ctx, x)` to `ismissing!(ctx, x)` since it is mutating the context.

Closes #29 

NOTE: We aren't deprecating this because it currently isn't an exported API.