### PR TITLE
Imputor TestSuites

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Invenia Technical Computing"]
 version = "0.4.0"
 
 [deps]
-DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 IterTools = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Invenia Technical Computing"]
 version = "0.4.0"
 
 [deps]
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 IterTools = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/src/imputors.jl
+++ b/src/imputors.jl
@@ -76,6 +76,15 @@ function impute(data, imp::Imputor; kwargs...)
     return impute!(deepcopy(data), imp; kwargs...)
 end
 
+# Wrapper method intended to handle ambiguities between vector and row tables.
+function impute!(data::AbstractVector, imp::Imputor)
+    if istable(data)
+        return materializer(data)(impute!(Tables.columns(data), imp))
+    else
+        return _impute!(data, imp)
+    end
+end
+
 """
     impute!(data::AbstractMatrix, imp::Imputor; kwargs...)
 

--- a/src/imputors/drop.jl
+++ b/src/imputors/drop.jl
@@ -121,3 +121,10 @@ end
 # Add impute! methods to override the default behaviour in imputors.jl
 impute!(data::AbstractMatrix, imp::Union{DropObs, DropVars}) = impute(data, imp)
 impute!(data, imp::Union{DropObs, DropVars}) = impute(data, imp)
+function impute!(data::AbstractVector, imp::Union{DropObs, DropVars})
+    if istable(data)
+        return materializer(data)(impute!(Tables.columns(data), imp))
+    else
+        throw(MethodError(impute!, (data, imp)))
+    end
+end

--- a/src/imputors/drop.jl
+++ b/src/imputors/drop.jl
@@ -123,7 +123,7 @@ impute!(data::AbstractMatrix, imp::Union{DropObs, DropVars}) = impute(data, imp)
 impute!(data, imp::Union{DropObs, DropVars}) = impute(data, imp)
 function impute!(data::AbstractVector, imp::Union{DropObs, DropVars})
     if istable(data)
-        return materializer(data)(impute!(Tables.columns(data), imp))
+        return materializer(data)(impute(Tables.columns(data), imp))
     else
         throw(MethodError(impute!, (data, imp)))
     end

--- a/src/imputors/fill.jl
+++ b/src/imputors/fill.jl
@@ -37,8 +37,14 @@ Fill(; value=mean, context=Context()) = Fill(value, context)
 function impute!(data::AbstractVector, imp::Fill)
     imp.context() do c
         fill_val = if isa(imp.value, Function)
-            # Call `deepcopy` because we can trust that it's available for all types.
-            imp.value(Impute.drop(data; context=c))
+            available = Impute.drop(data; context=c)
+
+            if isempty(available)
+                @warn "Cannot apply fill function $(imp.value) as all values are missing"
+                return data
+            else
+                imp.value(available)
+            end
         else
             imp.value
         end

--- a/src/imputors/fill.jl
+++ b/src/imputors/fill.jl
@@ -34,7 +34,7 @@ end
 # TODO: Switch to using Base.@kwdef on 1.1
 Fill(; value=mean, context=Context()) = Fill(value, context)
 
-function impute!(data::AbstractVector, imp::Fill)
+function _impute!(data::AbstractVector, imp::Fill)
     imp.context() do c
         fill_val = if isa(imp.value, Function)
             available = Impute.drop(data; context=c)

--- a/src/imputors/fill.jl
+++ b/src/imputors/fill.jl
@@ -40,7 +40,7 @@ function _impute!(data::AbstractVector, imp::Fill)
             available = Impute.drop(data; context=c)
 
             if isempty(available)
-                @warn "Cannot apply fill function $(imp.value) as all values are missing"
+                @debug "Cannot apply fill function $(imp.value) as all values are missing"
                 return data
             else
                 imp.value(available)

--- a/src/imputors/interp.jl
+++ b/src/imputors/interp.jl
@@ -35,9 +35,15 @@ end
 # TODO: Switch to using Base.@kwdef on 1.1
 Interpolate(; context=Context()) = Interpolate(context)
 
+function impute!(data::AbstractVector{Missing}, imp::Interpolate)
+    @warn "Cannot interpolate points when all values are missing"
+    return data
+end
+
 function impute!(data::AbstractVector{<:Union{T, Missing}}, imp::Interpolate) where T
     imp.context() do c
         i = findfirst(c, data) + 1
+        i < lastindex(data) || @warn "Cannot interpolate points when all values are missing"
 
         while i < lastindex(data)
             if ismissing!(c, data[i])

--- a/src/imputors/interp.jl
+++ b/src/imputors/interp.jl
@@ -37,7 +37,12 @@ Interpolate(; context=Context()) = Interpolate(context)
 
 function impute!(data::AbstractVector{Missing}, imp::Interpolate)
     @warn "Cannot interpolate points when all values are missing"
-    return data
+
+    # NOTE: We still do this so we can throw an ImputeError if the context has a limit set.
+    imp.context() do c
+        findfirst(c, data)
+        return data
+    end
 end
 
 function impute!(data::AbstractVector{<:Union{T, Missing}}, imp::Interpolate) where T

--- a/src/imputors/interp.jl
+++ b/src/imputors/interp.jl
@@ -36,7 +36,7 @@ end
 Interpolate(; context=Context()) = Interpolate(context)
 
 function _impute!(data::AbstractVector{Missing}, imp::Interpolate)
-    @warn "Cannot interpolate points when all values are missing"
+    @debug "Cannot interpolate points when all values are missing"
 
     # NOTE: We still do this so we can throw an ImputeError if the context has a limit set.
     imp.context() do c
@@ -48,7 +48,7 @@ end
 function _impute!(data::AbstractVector{<:Union{T, Missing}}, imp::Interpolate) where T
     imp.context() do c
         i = findfirst(c, data) + 1
-        i < lastindex(data) || @warn "Cannot interpolate points when all values are missing"
+        i < lastindex(data) || @debug "Cannot interpolate points when all values are missing"
 
         while i < lastindex(data)
             if ismissing!(c, data[i])

--- a/src/imputors/interp.jl
+++ b/src/imputors/interp.jl
@@ -35,7 +35,7 @@ end
 # TODO: Switch to using Base.@kwdef on 1.1
 Interpolate(; context=Context()) = Interpolate(context)
 
-function impute!(data::AbstractVector{Missing}, imp::Interpolate)
+function _impute!(data::AbstractVector{Missing}, imp::Interpolate)
     @warn "Cannot interpolate points when all values are missing"
 
     # NOTE: We still do this so we can throw an ImputeError if the context has a limit set.
@@ -45,7 +45,7 @@ function impute!(data::AbstractVector{Missing}, imp::Interpolate)
     end
 end
 
-function impute!(data::AbstractVector{<:Union{T, Missing}}, imp::Interpolate) where T
+function _impute!(data::AbstractVector{<:Union{T, Missing}}, imp::Interpolate) where T
     imp.context() do c
         i = findfirst(c, data) + 1
         i < lastindex(data) || @warn "Cannot interpolate points when all values are missing"

--- a/src/imputors/locf.jl
+++ b/src/imputors/locf.jl
@@ -40,7 +40,13 @@ LOCF(; context=Context()) = LOCF(context)
 
 function impute!(data::AbstractVector, imp::LOCF)
     imp.context() do c
-        start_idx = findfirst(c, data) + 1
+        start_idx = findfirst(c, data)
+        if start_idx === nothing
+            @warn "Cannot carry forward points when all values are missing"
+            return data
+        end
+
+        start_idx += 1
         for i in start_idx:lastindex(data)
             if ismissing!(c, data[i])
                 data[i] = data[i-1]

--- a/src/imputors/locf.jl
+++ b/src/imputors/locf.jl
@@ -38,7 +38,7 @@ end
 # TODO: Switch to using Base.@kwdef on 1.1
 LOCF(; context=Context()) = LOCF(context)
 
-function impute!(data::AbstractVector, imp::LOCF)
+function _impute!(data::AbstractVector, imp::LOCF)
     imp.context() do c
         start_idx = findfirst(c, data)
         if start_idx === nothing

--- a/src/imputors/locf.jl
+++ b/src/imputors/locf.jl
@@ -42,7 +42,7 @@ function _impute!(data::AbstractVector, imp::LOCF)
     imp.context() do c
         start_idx = findfirst(c, data)
         if start_idx === nothing
-            @warn "Cannot carry forward points when all values are missing"
+            @debug "Cannot carry forward points when all values are missing"
             return data
         end
 

--- a/src/imputors/nocb.jl
+++ b/src/imputors/nocb.jl
@@ -41,7 +41,7 @@ function _impute!(data::AbstractVector, imp::NOCB)
     imp.context() do c
         end_idx = findlast(c, data)
         if end_idx === nothing
-            @warn "Cannot carry backward points when all values are missing"
+            @debug "Cannot carry backward points when all values are missing"
             return data
         end
 

--- a/src/imputors/nocb.jl
+++ b/src/imputors/nocb.jl
@@ -37,7 +37,7 @@ end
 # TODO: Switch to using Base.@kwdef on 1.1
 NOCB(; context=Context()) = NOCB(context)
 
-function impute!(data::AbstractVector, imp::NOCB)
+function _impute!(data::AbstractVector, imp::NOCB)
     imp.context() do c
         end_idx = findlast(c, data)
         if end_idx === nothing

--- a/src/imputors/nocb.jl
+++ b/src/imputors/nocb.jl
@@ -39,7 +39,13 @@ NOCB(; context=Context()) = NOCB(context)
 
 function impute!(data::AbstractVector, imp::NOCB)
     imp.context() do c
-        end_idx = findlast(c, data) - 1
+        end_idx = findlast(c, data)
+        if end_idx === nothing
+            @warn "Cannot carry backward points when all values are missing"
+            return data
+        end
+
+        end_idx -= 1
         for i in end_idx:-1:firstindex(data)
             if ismissing!(c, data[i])
                 data[i] = data[i+1]

--- a/src/imputors/srs.jl
+++ b/src/imputors/srs.jl
@@ -42,7 +42,7 @@ SRS(; rng=Random.GLOBAL_RNG, context=Context()) = SRS(rng, context)
 
 function impute!(data::AbstractVector, imp::SRS)
     imp.context() do c
-        obs_values = Impute.dropobs(data)
+        obs_values = Impute.dropobs(data; context=imp.context)
         if !isempty(obs_values)
             for i in eachindex(data)
                 if ismissing!(c, data[i])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,16 +31,8 @@ using Impute:
     a = allowmissing(1.0:1.0:20.0)
     a[[2, 3, 7]] .= missing
     mask = map(!ismissing, a)
-    ctx = Context(; limit=0.2)
 
-    # We call collect to not have a wrapper type that references the same data.
     m = collect(reshape(a, 5, 4))
-
-    aa = AxisArray(
-        deepcopy(m),
-        Axis{:time}(DateTime(2017, 6, 5, 5):Hour(1):DateTime(2017, 6, 5, 9)),
-        Axis{:id}(1:4)
-    )
 
     table = DataFrame(
         :sin => allowmissing(sin.(1.0:1.0:20.0)),
@@ -49,106 +41,31 @@ using Impute:
 
     table.sin[[2, 3, 7, 12, 19]] .= missing
 
-    @testset "Equality" begin
-        @testset "$T" for T in (DropObs, DropVars, Interpolate, Fill, LOCF, NOCB, SRS)
-            @test T() == T()
-        end
+    include("testutils.jl")
+
+    @testset "TestSuite: $T" for T in (DropObs, DropVars, Interpolate, Fill, LOCF, NOCB, SRS)
+        test_all(ImputorTester(T))
     end
 
     @testset "Drop" begin
         @testset "DropObs" begin
             @testset "Vector" begin
-                result = impute(a, DropObs(; context=ctx))
+                result = Impute.dropobs(a)
                 expected = deleteat!(deepcopy(a), [2, 3, 7])
-
                 @test result == expected
-                @test result == Impute.dropobs(a; context=ctx)
-
-                a2 = deepcopy(a)
-                Impute.dropobs!(a2; context=ctx)
-                @test a2 == expected
             end
 
             @testset "Matrix" begin
-                # Because we're removing 2 of our 5 rows we need to change the limit.
-                ctx = Context(; limit=0.4)
-                result = impute(m, DropObs(; context=ctx))
+                result = Impute.dropobs(m)
                 expected = m[[1, 4, 5], :]
-
                 @test isequal(result, expected)
-                @test isequal(result, Impute.dropobs(m; context=ctx))
-                @test isequal(collect(result'), Impute.dropobs(collect(m'); dims=2, context=ctx))
-
-                m_ = Impute.dropobs!(m; context=ctx)
-                # The mutating test is broken because we need to making a copy of
-                # the original matrix
-                @test_broken isequal(m, expected)
-                @test isequal(m_, expected)
             end
 
-            @testset "Tables" begin
-                ctx = Context(; limit=0.4)
-                @testset "DataFrame" begin
-                    df = deepcopy(table)
-                    result = impute(df, DropObs(; context=ctx))
-                    expected = dropmissing(df)
-
-                    @test isequal(result, expected)
-                    @test isequal(result, Impute.dropobs(df; context=ctx))
-
-                    df_ = Impute.dropobs!(df; context=ctx)
-                    # The mutating test is broken because we need to making a copy of
-                    # the original table
-                    @test_broken isequal(df, expected)
-                    @test isequal(df_, expected)
-                end
-
-                @testset "Column Table" begin
-                    coltab = Tables.columntable(table)
-
-                    result = impute(coltab, DropObs(; context=ctx))
-                    expected = Tables.columntable(dropmissing(table))
-
-                    @test isequal(result, expected)
-                    @test isequal(result, Impute.dropobs(coltab; context=ctx))
-
-                    coltab_ = Impute.dropobs!(coltab; context=ctx)
-                    # The mutating test is broken because we need to making a copy of
-                    # the original table
-                    @test_broken isequal(coltab, expected)
-                    @test isequal(coltab_, expected)
-                end
-
-                @testset "Row Table" begin
-                    rowtab = Tables.rowtable(table)
-                    result = impute(rowtab, DropObs(; context=ctx))
-                    expected = Tables.rowtable(dropmissing(table))
-
-                    @test isequal(result, expected)
-                    @test isequal(result, Impute.dropobs(rowtab; context=ctx))
-
-                    rowtab_ = Impute.dropobs!(rowtab; context=ctx)
-                    # The mutating test is broken because we need to making a copy of
-                    # the original table
-                    # @test_broken isequal(rowtab, expected)
-                    @test isequal(rowtab_, expected)
-                end
-            end
-
-            @testset "AxisArray" begin
-                # Because we're removing 2 of our 5 rows we need to change the limit.
-                ctx = Context(; limit=0.4)
-                result = impute(aa, DropObs(; context=ctx))
-                expected = aa[[1, 4, 5], :]
-
+            @testset "DataFrame" begin
+                df = deepcopy(table)
+                result = Impute.dropobs(df)
+                expected = dropmissing(df)
                 @test isequal(result, expected)
-                @test isequal(result, Impute.dropobs(aa; context=ctx))
-
-                aa_ = Impute.dropobs!(aa; context=ctx)
-                # The mutating test is broken because we need to making a copy of
-                # the original matrix
-                @test_broken isequal(aa, expected)
-                @test isequal(aa_, expected)
             end
         end
 
@@ -158,166 +75,53 @@ using Impute:
             end
 
             @testset "Matrix" begin
-                ctx = Context(; limit=0.5)
-                result = impute(m, DropVars(; context=ctx))
+                result = Impute.dropvars(m)
                 expected = copy(m)[:, 3:4]
-
                 @test isequal(result, expected)
-                @test isequal(result, Impute.dropvars(m; context=ctx))
-                @test isequal(collect(result'), Impute.dropvars(collect(m'); dims=2, context=ctx))
-
-                m_ = Impute.dropvars!(m; context=ctx)
-                # The mutating test is broken because we need to making a copy of
-                # the original matrix
-                @test_broken isequal(m, expected)
-                @test isequal(m_, expected)
             end
 
-            @testset "Tables" begin
-                @testset "DataFrame" begin
-                    df = deepcopy(table)
-                    result = impute(df, DropVars(; context=ctx))
-                    expected = select(df, :cos)
-
-                    @test isequal(result, expected)
-                    @test isequal(result, Impute.dropvars(df; context=ctx))
-
-                    Impute.dropvars!(df; context=ctx)
-                    # The mutating test is broken because we need to making a copy of
-                    # the original table
-                    @test_broken isequal(df, expected)
-                end
-
-                @testset "Column Table" begin
-                    coltab = Tables.columntable(table)
-
-                    result = impute(coltab, DropVars(; context=ctx))
-                    expected = Tables.columntable(Tables.select(coltab, :cos))
-
-                    @test isequal(result, expected)
-                    @test isequal(result, Impute.dropvars(coltab; context=ctx))
-
-                    Impute.dropvars!(coltab; context=ctx)
-                    # The mutating test is broken because we need to making a copy of
-                    # the original table
-                    @test_broken isequal(coltab, expected)
-                end
-
-                @testset "Row Table" begin
-                    rowtab = Tables.rowtable(table)
-                    result = impute(rowtab, DropVars(; context=ctx))
-                    expected = Tables.rowtable(Tables.select(rowtab, :cos))
-
-                    @test isequal(result, expected)
-                    @test isequal(result, Impute.dropvars(rowtab; context=ctx))
-
-                    Impute.dropvars!(rowtab; context=ctx)
-                    # The mutating test is broken because we need to making a copy of
-                    # the original table
-                    @test_broken isequal(rowtab, expected)
-                end
-            end
-            @testset "AxisArray" begin
-                ctx = Context(; limit=0.5)
-                result = impute(aa, DropVars(; context=ctx))
-                expected = copy(aa)[:, 3:4]
+            @testset "DataFrame" begin
+                df = deepcopy(table)
+                result = Impute.dropvars(df)
+                expected = select(df, :cos)
 
                 @test isequal(result, expected)
-                @test isequal(result, Impute.dropvars(aa; context=ctx))
-
-                aa_ = Impute.dropvars!(aa; context=ctx)
-                # The mutating test is broken because we need to making a copy of
-                # the original matrix
-                @test_broken isequal(aa, expected)
-                @test isequal(aa_, expected)
             end
         end
     end
 
     @testset "Interpolate" begin
-        result = impute(a, Interpolate(; context=ctx))
-        @test result == collect(1.0:1.0:20)
-        @test result == interp(a; context=ctx)
-
-        # Test in-place method
-        a2 = copy(a)
-        Impute.interp!(a2; context=ctx)
-        @test a2 == result
-
-        # Test interpolation between identical points
-        b = ones(Union{Float64, Missing}, 20)
-        b[[2, 3, 7]] .= missing
-        @test interp(b; context=ctx) == ones(Union{Float64, Missing}, 20)
-
-        # Test interpolation at endpoints
-        b = ones(Union{Float64, Missing}, 20)
-        b[[1, 3, 20]] .= missing
-        result = interp(b; context=ctx)
-        @test ismissing(result[1])
-        @test ismissing(result[20])
+        @test interp(a) == collect(1.0:1.0:20)
     end
 
     @testset "Fill" begin
         @testset "Value" begin
             fill_val = -1.0
-            result = impute(a, Fill(; value=fill_val, context=ctx))
+            result = Impute.fill(a; value=fill_val)
             expected = copy(a)
             expected[[2, 3, 7]] .= fill_val
-
             @test result == expected
-            @test result == Impute.fill(a; value=fill_val, context=ctx)
         end
 
         @testset "Mean" begin
-            result = impute(a, Fill(; value=mean, context=ctx))
+            result = Impute.fill(a; value=mean)
             expected = copy(a)
             expected[[2, 3, 7]] .= mean(a[mask])
-
             @test result == expected
-            @test result == Impute.fill(a; value=mean, context=ctx)
-
-            a2 = copy(a)
-            Impute.fill!(a2; context=ctx)
-            @test a2 == result
-        end
-
-        @testset "Matrix" begin
-            ctx = Context(; limit=1.0)
-            expected = Matrix(Impute.dropobs(dataset("boot", "neuro"); context=ctx))
-            data = Matrix(dataset("boot", "neuro"))
-
-            result = impute(data, Fill(; value=0.0, context=ctx))
-            @test size(result) == size(data)
-            @test result == Impute.fill(data; value=0.0, context=ctx)
-
-            data2 = copy(data)
-            Impute.fill!(data2; value=0.0, context=ctx)
-            @test data2 == result
         end
     end
 
     @testset "LOCF" begin
-        result = impute(a, LOCF(; context=ctx))
+        result = Impute.locf(a)
         expected = copy(a)
-        expected[2] = 1.0
-        expected[3] = 1.0
-        expected[7] = 6.0
-
+        expected[[2, 3, 7]] = [1.0, 1.0, 6.0]
         @test result == expected
-        @test result == Impute.locf(a; context=ctx)
-
-        a2 = copy(a)
-        Impute.locf!(a2; context=ctx)
-        @test a2 == result
     end
 
     @testset "NOCB" begin
-        result = impute(a, NOCB(; context=ctx))
+        result = Impute.nocb(a)
         expected = copy(a)
-        expected[2] = 4.0
-        expected[3] = 4.0
-        expected[7] = 8.0
-
+        expected[[2, 3, 7]] = [4.0, 4.0, 8.0]
         @test result == expected
         @test result == Impute.nocb(a; context=ctx)
 
@@ -349,6 +153,7 @@ using Impute:
         @test_throws ImputeError Impute.dropobs(a; context=ctx)
     end
 
+    # TODO: Flush out the Chain interface to better fit the TestSuite?
     @testset "Chain" begin
         orig = dataset("boot", "neuro")
         ctx = Context(; limit=1.0)
@@ -517,9 +322,4 @@ using Impute:
     end
 
     include("deprecated.jl")
-    include("testutils.jl")
-
-    @testset "$T" for T in (DropObs, DropVars, Interpolate, Fill, LOCF, NOCB)
-        test_all(ImputorTester(T))
-    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -123,28 +123,13 @@ using Impute:
         expected = copy(a)
         expected[[2, 3, 7]] = [4.0, 4.0, 8.0]
         @test result == expected
-        @test result == Impute.nocb(a; context=ctx)
-
-        a2 = copy(a)
-        Impute.nocb!(a2; context=ctx)
-        @test a2 == result
     end
 
     @testset "SRS" begin
-        result = impute(a, SRS(; rng=MersenneTwister(137), context=ctx))
+        result = Impute.srs(a; rng=MersenneTwister(137))
         expected = copy(a)
-        expected[2] = 9.0
-        expected[3] = 16.0
-        expected[7] = 17.0
-
+        expected[[2, 3, 7]] = [9.0, 16.0, 17.0]
         @test result == expected
-
-        @test result == Impute.srs(a; rng=MersenneTwister(137), context=ctx)
-
-        a2 = copy(a)
-
-        Impute.srs!(a2; rng=MersenneTwister(137), context=ctx)
-        @test a2 == result
     end
 
     @testset "Not enough data" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,4 @@
+using Impute
 using Tables
 using Test
 using AxisArrays
@@ -31,8 +32,16 @@ using Impute:
     a = allowmissing(1.0:1.0:20.0)
     a[[2, 3, 7]] .= missing
     mask = map(!ismissing, a)
+    ctx = Context(; limit=0.2)
 
+    # We call collect to not have a wrapper type that references the same data.
     m = collect(reshape(a, 5, 4))
+
+    aa = AxisArray(
+        deepcopy(m),
+        Axis{:time}(DateTime(2017, 6, 5, 5):Hour(1):DateTime(2017, 6, 5, 9)),
+        Axis{:id}(1:4)
+    )
 
     table = DataFrame(
         :sin => allowmissing(sin.(1.0:1.0:20.0)),
@@ -41,31 +50,106 @@ using Impute:
 
     table.sin[[2, 3, 7, 12, 19]] .= missing
 
-    include("testutils.jl")
-
-    @testset "TestSuite: $T" for T in (DropObs, DropVars, Interpolate, Fill, LOCF, NOCB, SRS)
-        test_all(ImputorTester(T))
+    @testset "Equality" begin
+        @testset "$T" for T in (DropObs, DropVars, Interpolate, Fill, LOCF, NOCB, SRS)
+            @test T() == T()
+        end
     end
 
     @testset "Drop" begin
         @testset "DropObs" begin
             @testset "Vector" begin
-                result = Impute.dropobs(a)
+                result = impute(a, DropObs(; context=ctx))
                 expected = deleteat!(deepcopy(a), [2, 3, 7])
+
                 @test result == expected
+                @test result == Impute.dropobs(a; context=ctx)
+
+                a2 = deepcopy(a)
+                Impute.dropobs!(a2; context=ctx)
+                @test a2 == expected
             end
 
             @testset "Matrix" begin
-                result = Impute.dropobs(m)
+                # Because we're removing 2 of our 5 rows we need to change the limit.
+                ctx = Context(; limit=0.4)
+                result = impute(m, DropObs(; context=ctx))
                 expected = m[[1, 4, 5], :]
+
                 @test isequal(result, expected)
+                @test isequal(result, Impute.dropobs(m; context=ctx))
+                @test isequal(collect(result'), Impute.dropobs(collect(m'); dims=2, context=ctx))
+
+                m_ = Impute.dropobs!(m; context=ctx)
+                # The mutating test is broken because we need to making a copy of
+                # the original matrix
+                @test_broken isequal(m, expected)
+                @test isequal(m_, expected)
             end
 
-            @testset "DataFrame" begin
-                df = deepcopy(table)
-                result = Impute.dropobs(df)
-                expected = dropmissing(df)
+            @testset "Tables" begin
+                ctx = Context(; limit=0.4)
+                @testset "DataFrame" begin
+                    df = deepcopy(table)
+                    result = impute(df, DropObs(; context=ctx))
+                    expected = dropmissing(df)
+
+                    @test isequal(result, expected)
+                    @test isequal(result, Impute.dropobs(df; context=ctx))
+
+                    df_ = Impute.dropobs!(df; context=ctx)
+                    # The mutating test is broken because we need to making a copy of
+                    # the original table
+                    @test_broken isequal(df, expected)
+                    @test isequal(df_, expected)
+                end
+
+                @testset "Column Table" begin
+                    coltab = Tables.columntable(table)
+
+                    result = impute(coltab, DropObs(; context=ctx))
+                    expected = Tables.columntable(dropmissing(table))
+
+                    @test isequal(result, expected)
+                    @test isequal(result, Impute.dropobs(coltab; context=ctx))
+
+                    coltab_ = Impute.dropobs!(coltab; context=ctx)
+                    # The mutating test is broken because we need to making a copy of
+                    # the original table
+                    @test_broken isequal(coltab, expected)
+                    @test isequal(coltab_, expected)
+                end
+
+                @testset "Row Table" begin
+                    rowtab = Tables.rowtable(table)
+                    result = impute(rowtab, DropObs(; context=ctx))
+                    expected = Tables.rowtable(dropmissing(table))
+
+                    @test isequal(result, expected)
+                    @test isequal(result, Impute.dropobs(rowtab; context=ctx))
+
+                    rowtab_ = Impute.dropobs!(rowtab; context=ctx)
+                    # The mutating test is broken because we need to making a copy of
+                    # the original table
+                    # @test_broken isequal(rowtab, expected)
+                    @test isequal(rowtab_, expected)
+                end
+            end
+
+            @testset "AxisArray" begin
+                # Because we're removing 2 of our 5 rows we need to change the limit.
+                ctx = Context(; limit=0.4)
+                result = impute(aa, DropObs(; context=ctx))
+                expected = aa[[1, 4, 5], :]
+
                 @test isequal(result, expected)
+                @test isequal(result, Impute.dropobs(aa; context=ctx))
+
+                aa_ = Impute.dropobs!(aa; context=ctx)
+                # The mutating test is broken because we need to making a copy of
+                # the original matrix
+                @test_broken isequal(aa, expected)
+                @test isequal(aa_, expected)
             end
         end
 
@@ -75,61 +159,189 @@ using Impute:
             end
 
             @testset "Matrix" begin
-                result = Impute.dropvars(m)
+                ctx = Context(; limit=0.5)
+                result = impute(m, DropVars(; context=ctx))
                 expected = copy(m)[:, 3:4]
+
                 @test isequal(result, expected)
+                @test isequal(result, Impute.dropvars(m; context=ctx))
+                @test isequal(collect(result'), Impute.dropvars(collect(m'); dims=2, context=ctx))
+
+                m_ = Impute.dropvars!(m; context=ctx)
+                # The mutating test is broken because we need to making a copy of
+                # the original matrix
+                @test_broken isequal(m, expected)
+                @test isequal(m_, expected)
             end
 
-            @testset "DataFrame" begin
-                df = deepcopy(table)
-                result = Impute.dropvars(df)
-                expected = select(df, :cos)
+            @testset "Tables" begin
+                @testset "DataFrame" begin
+                    df = deepcopy(table)
+                    result = impute(df, DropVars(; context=ctx))
+                    expected = select(df, :cos)
+
+                    @test isequal(result, expected)
+                    @test isequal(result, Impute.dropvars(df; context=ctx))
+
+                    Impute.dropvars!(df; context=ctx)
+                    # The mutating test is broken because we need to making a copy of
+                    # the original table
+                    @test_broken isequal(df, expected)
+                end
+
+                @testset "Column Table" begin
+                    coltab = Tables.columntable(table)
+
+                    result = impute(coltab, DropVars(; context=ctx))
+                    expected = Tables.columntable(Tables.select(coltab, :cos))
+
+                    @test isequal(result, expected)
+                    @test isequal(result, Impute.dropvars(coltab; context=ctx))
+
+                    Impute.dropvars!(coltab; context=ctx)
+                    # The mutating test is broken because we need to making a copy of
+                    # the original table
+                    @test_broken isequal(coltab, expected)
+                end
+
+                @testset "Row Table" begin
+                    rowtab = Tables.rowtable(table)
+                    result = impute(rowtab, DropVars(; context=ctx))
+                    expected = Tables.rowtable(Tables.select(rowtab, :cos))
+
+                    @test isequal(result, expected)
+                    @test isequal(result, Impute.dropvars(rowtab; context=ctx))
+
+                    Impute.dropvars!(rowtab; context=ctx)
+                    # The mutating test is broken because we need to making a copy of
+                    # the original table
+                    @test_broken isequal(rowtab, expected)
+                end
+            end
+            @testset "AxisArray" begin
+                ctx = Context(; limit=0.5)
+                result = impute(aa, DropVars(; context=ctx))
+                expected = copy(aa)[:, 3:4]
 
                 @test isequal(result, expected)
+                @test isequal(result, Impute.dropvars(aa; context=ctx))
+
+                aa_ = Impute.dropvars!(aa; context=ctx)
+                # The mutating test is broken because we need to making a copy of
+                # the original matrix
+                @test_broken isequal(aa, expected)
+                @test isequal(aa_, expected)
             end
         end
     end
 
     @testset "Interpolate" begin
-        @test interp(a) == collect(1.0:1.0:20)
+        result = impute(a, Interpolate(; context=ctx))
+        @test result == collect(1.0:1.0:20)
+        @test result == interp(a; context=ctx)
+
+        # Test in-place method
+        a2 = copy(a)
+        Impute.interp!(a2; context=ctx)
+        @test a2 == result
+
+        # Test interpolation between identical points
+        b = ones(Union{Float64, Missing}, 20)
+        b[[2, 3, 7]] .= missing
+        @test interp(b; context=ctx) == ones(Union{Float64, Missing}, 20)
+
+        # Test interpolation at endpoints
+        b = ones(Union{Float64, Missing}, 20)
+        b[[1, 3, 20]] .= missing
+        result = interp(b; context=ctx)
+        @test ismissing(result[1])
+        @test ismissing(result[20])
     end
 
     @testset "Fill" begin
         @testset "Value" begin
             fill_val = -1.0
-            result = Impute.fill(a; value=fill_val)
+            result = impute(a, Fill(; value=fill_val, context=ctx))
             expected = copy(a)
             expected[[2, 3, 7]] .= fill_val
+
             @test result == expected
+            @test result == Impute.fill(a; value=fill_val, context=ctx)
         end
 
         @testset "Mean" begin
-            result = Impute.fill(a; value=mean)
+            result = impute(a, Fill(; value=mean, context=ctx))
             expected = copy(a)
             expected[[2, 3, 7]] .= mean(a[mask])
+
             @test result == expected
+            @test result == Impute.fill(a; value=mean, context=ctx)
+
+            a2 = copy(a)
+            Impute.fill!(a2; context=ctx)
+            @test a2 == result
+        end
+
+        @testset "Matrix" begin
+            ctx = Context(; limit=1.0)
+            expected = Matrix(Impute.dropobs(dataset("boot", "neuro"); context=ctx))
+            data = Matrix(dataset("boot", "neuro"))
+
+            result = impute(data, Fill(; value=0.0, context=ctx))
+            @test size(result) == size(data)
+            @test result == Impute.fill(data; value=0.0, context=ctx)
+
+            data2 = copy(data)
+            Impute.fill!(data2; value=0.0, context=ctx)
+            @test data2 == result
         end
     end
 
     @testset "LOCF" begin
-        result = Impute.locf(a)
+        result = impute(a, LOCF(; context=ctx))
         expected = copy(a)
-        expected[[2, 3, 7]] = [1.0, 1.0, 6.0]
+        expected[2] = 1.0
+        expected[3] = 1.0
+        expected[7] = 6.0
+
         @test result == expected
+        @test result == Impute.locf(a; context=ctx)
+
+        a2 = copy(a)
+        Impute.locf!(a2; context=ctx)
+        @test a2 == result
     end
 
     @testset "NOCB" begin
-        result = Impute.nocb(a)
+        result = impute(a, NOCB(; context=ctx))
         expected = copy(a)
-        expected[[2, 3, 7]] = [4.0, 4.0, 8.0]
+        expected[2] = 4.0
+        expected[3] = 4.0
+        expected[7] = 8.0
+
         @test result == expected
+        @test result == Impute.nocb(a; context=ctx)
+
+        a2 = copy(a)
+        Impute.nocb!(a2; context=ctx)
+        @test a2 == result
     end
 
     @testset "SRS" begin
-        result = Impute.srs(a; rng=MersenneTwister(137))
+        result = impute(a, SRS(; rng=MersenneTwister(137), context=ctx))
         expected = copy(a)
-        expected[[2, 3, 7]] = [9.0, 16.0, 17.0]
+        expected[2] = 9.0
+        expected[3] = 16.0
+        expected[7] = 17.0
+
         @test result == expected
+
+        @test result == Impute.srs(a; rng=MersenneTwister(137), context=ctx)
+
+        a2 = copy(a)
+
+        Impute.srs!(a2; rng=MersenneTwister(137), context=ctx)
+        @test a2 == result
     end
 
     @testset "Not enough data" begin
@@ -138,7 +350,6 @@ using Impute:
         @test_throws ImputeError Impute.dropobs(a; context=ctx)
     end
 
-    # TODO: Flush out the Chain interface to better fit the TestSuite?
     @testset "Chain" begin
         orig = dataset("boot", "neuro")
         ctx = Context(; limit=1.0)
@@ -307,4 +518,9 @@ using Impute:
     end
 
     include("deprecated.jl")
+    include("testutils.jl")
+
+    @testset "$T" for T in (DropObs, DropVars, Interpolate, Fill, LOCF, NOCB)
+        test_all(ImputorTester(T))
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,3 @@
-using Impute
 using Tables
 using Test
 using AxisArrays
@@ -10,6 +9,8 @@ using StatsBase
 using Random
 
 using Impute:
+    Impute,
+    Imputor,
     Drop,
     DropObs,
     DropVars,
@@ -516,4 +517,9 @@ using Impute:
     end
 
     include("deprecated.jl")
+    include("testutils.jl")
+
+    @testset "$T" for T in (DropObs, DropVars, Interpolate, Fill, LOCF, NOCB)
+        test_all(ImputorTester(T))
+    end
 end

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -77,16 +77,14 @@ function test_vector(tester::ImputorTester)
                 end
             end
 
-            # @testset "Too many missing values" begin
-            #     # Test Context error condition
-            #     c = fill(missing, 10)
-            #     settings = deepcopy(tester.kwargs)
-            #     settings[:context] = Context(; limit=0.1)
-            #     # @test_throws ImputeError
-            #     impute(c, tester.imp(; settings...))
-            #     # @test_throws ImputeError
-            #     tester.f(c; settings...)
-            # end
+            @testset "Too many missing values" begin
+                # Test Context error condition
+                c = fill(missing, 10)
+                settings = deepcopy(tester.kwargs)
+                settings[:context] = Context(; limit=0.1)
+                @test_throws ImputeError impute(c, tester.imp(; settings...))
+                @test_throws ImputeError tester.f(c; settings...)
+            end
         end
     end
 end
@@ -138,14 +136,14 @@ function test_matrix(tester::ImputorTester)
             end
         end
 
-        # @testset "Too many missing values" begin
-        #     # Test Context error condition
-        #     c = fill(missing, 5, 2)
-        #     settings = deepcopy(tester.kwargs)
-        #     settings[:context] = Context(; limit=0.1)
-        #     @test_throws ImputeError impute(c, tester.imp(; settings...))
-        #     @test_throws ImputeError tester.f(c; settings...)
-        # end
+        @testset "Too many missing values" begin
+            # Test Context error condition
+            c = fill(missing, 5, 2)
+            settings = deepcopy(tester.kwargs)
+            settings[:context] = Context(; limit=0.1)
+            @test_throws ImputeError impute(c, tester.imp(; settings...))
+            @test_throws ImputeError tester.f(c; settings...)
+        end
     end
 end
 
@@ -205,18 +203,22 @@ function test_dataframe(tester::ImputorTester)
             end
         end
 
-        # @testset "Too many missing values" begin
-        #     # Test Context error condition
-        #     c = DataFrame(
-        #         :sin => fill(missing, 10),
-        #         :cos => fill(missing, 10),
-        #     )
-        #     settings = deepcopy(tester.kwargs)
-        #     settings[:context] = Context(; limit=0.1)
-        #     # @test_throws ImputeError
-        #     impute(c, tester.imp(; settings...))
-        #     # @test_throws ImputeError
-        #     tester.f(c; settings...)
-        # end
+        @testset "Too many missing values" begin
+            # Test Context error condition
+            c = DataFrame(
+                :sin => fill(missing, 10),
+                :cos => fill(missing, 10),
+            )
+            settings = deepcopy(tester.kwargs)
+            settings[:context] = Context(; limit=0.1)
+            if tester.imp == DropVars
+                # https://github.com/JuliaData/Tables.jl/issues/117
+                @test_throws MethodError impute(c, tester.imp(; settings...))
+                @test_throws MethodError tester.f(c; settings...)
+            else
+                @test_throws ImputeError impute(c, tester.imp(; settings...))
+                @test_throws ImputeError tester.f(c; settings...)
+            end
+        end
     end
 end

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -67,15 +67,15 @@ function test_vector(tester::ImputorTester)
                 @test impute(b, tester.imp(; tester.kwargs...)) == b
             end
 
-            # @testset "All missing" begin
-            #     # Test having only missing data
-            #     c = fill(missing, 10)
-            #     if tester.imp != Impute.DropObs
-            #         @test impute(c, tester.imp(; tester.kwargs...)) == c
-            #     else
-            #         @test impute(c, tester.imp(; tester.kwargs...)) == empty(c)
-            #     end
-            # end
+            @testset "All missing" begin
+                # Test having only missing data
+                c = fill(missing, 10)
+                if tester.imp != Impute.DropObs
+                    @test isequal(impute(c, tester.imp(; tester.kwargs...)), c)
+                else
+                    @test impute(c, tester.imp(; tester.kwargs...)) == empty(c)
+                end
+            end
 
             # @testset "Too many missing values" begin
             #     # Test Context error condition
@@ -126,17 +126,17 @@ function test_matrix(tester::ImputorTester)
             @test impute(b, tester.imp(; tester.kwargs...)) == b
         end
 
-        # @testset "All missing" begin
-        #     # Test having only missing data
-        #     c = fill(missing, 5, 2)
-        #     if tester.imp == DropObs
-        #         @test impute(c, tester.imp(; tester.kwargs...)) == Matrix{Missing}(missing, 0, 2)
-        #     elseif tester.imp == DropVars
-        #         @test impute(c, tester.imp(; tester.kwargs...)) == Matrix{Missing}(missing, 5, 0)
-        #     else
-        #         @test impute(c, tester.imp(; tester.kwargs...)) == c
-        #     end
-        # end
+        @testset "All missing" begin
+            # Test having only missing data
+            c = fill(missing, 5, 2)
+            if tester.imp == DropObs
+                @test impute(c, tester.imp(; tester.kwargs...)) == Matrix{Missing}(missing, 0, 2)
+            elseif tester.imp == DropVars
+                @test impute(c, tester.imp(; tester.kwargs...)) == Matrix{Missing}(missing, 5, 0)
+            else
+                @test isequal(impute(c, tester.imp(; tester.kwargs...)), c)
+            end
+        end
 
         # @testset "Too many missing values" begin
         #     # Test Context error condition
@@ -189,18 +189,21 @@ function test_dataframe(tester::ImputorTester)
             @test impute(b, tester.imp(; tester.kwargs...)) == b
         end
 
-        # @testset "All missing" begin
-        #     # Test having only missing data
-        #     c = DataFrame(
-        #         :sin => fill(missing, 10),
-        #         :cos => fill(missing, 10),
-        #     )
-        #     if tester.imp == DropObs || tester.imp == DropVars
-        #         @test impute(c, tester.imp(; tester.kwargs...)) == DataFrame()
-        #     else
-        #         @test impute(c, tester.imp(; tester.kwargs...)) == c
-        #     end
-        # end
+        @testset "All missing" begin
+            # Test having only missing data
+            c = DataFrame(
+                :sin => fill(missing, 10),
+                :cos => fill(missing, 10),
+            )
+            if tester.imp == DropObs
+                @test impute(c, tester.imp(; tester.kwargs...)) == DataFrame()
+            elseif tester.imp == DropVars
+                # https://github.com/JuliaData/Tables.jl/issues/117
+                @test_broken impute(c, tester.imp(; tester.kwargs...)) == DataFrame()
+            else
+                @test isequal(impute(c, tester.imp(; tester.kwargs...)), c)
+            end
+        end
 
         # @testset "Too many missing values" begin
         #     # Test Context error condition

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -127,7 +127,7 @@ function test_matrix(tester::ImputorTester)
             result_ = collect(result')
             @test isequal(tester.f(m_; dims=2, tester.kwargs...), result_)
 
-            if tester.imp != DropVars && tester.imp != DropObs
+            if !(tester.imp in (DropVars, DropObs, SRS))
                 @test isequal(tester.f!(m_; dims=2, tester.kwargs...), result_)
             end
         end
@@ -210,7 +210,7 @@ function test_dataframe(tester::ImputorTester)
                 @test impute(c, tester.imp(; tester.kwargs...)) == DataFrame()
             elseif tester.imp == DropVars
                 # https://github.com/JuliaData/Tables.jl/issues/117
-                @test_broken impute(c, tester.imp(; tester.kwargs...)) == DataFrame()
+                @test impute(c, tester.imp(; tester.kwargs...)) == DataFrame()
             else
                 @test isequal(impute(c, tester.imp(; tester.kwargs...)), c)
             end
@@ -223,14 +223,8 @@ function test_dataframe(tester::ImputorTester)
                 :cos => fill(missing, 10),
             )
             kwargs = merge(tester.kwargs, (context = Context(; limit=0.1),))
-            if tester.imp == DropVars
-                # https://github.com/JuliaData/Tables.jl/issues/117
-                @test_throws MethodError impute(c, tester.imp(; kwargs...))
-                @test_throws MethodError tester.f(c; kwargs...)
-            else
-                @test_throws ImputeError impute(c, tester.imp(; kwargs...))
-                @test_throws ImputeError tester.f(c; kwargs...)
-            end
+            @test_throws ImputeError impute(c, tester.imp(; kwargs...))
+            @test_throws ImputeError tester.f(c; kwargs...)
         end
     end
 end

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -26,7 +26,7 @@ function test_all(tester::ImputorTester)
     test_dataframe(tester)
     test_axisarray(tester)
     test_columntable(tester)
-    # test_rowtable(tester)
+    test_rowtable(tester)
 end
 
 function test_equality(tester::ImputorTester)
@@ -295,37 +295,36 @@ function test_columntable(tester::ImputorTester)
     end
 end
 
-# Row table tests will fail because vector input could be a row table or a vector of scalars
-# function test_rowtable(tester::ImputorTester)
-#     @testset "Row Table" begin
-#         table = DataFrame(
-#             :sin => allowmissing(sin.(1.0:1.0:20.0)),
-#             :cos => allowmissing(sin.(1.0:1.0:20.0)),
-#         )
+function test_rowtable(tester::ImputorTester)
+    @testset "Row Table" begin
+        table = DataFrame(
+            :sin => allowmissing(sin.(1.0:1.0:20.0)),
+            :cos => allowmissing(sin.(1.0:1.0:20.0)),
+        )
 
-#         table.sin[[2, 3, 7, 12, 19]] .= missing
-#         rowtab = Tables.rowtable(table)
+        table.sin[[2, 3, 7, 12, 19]] .= missing
+        rowtab = Tables.rowtable(table)
 
-#         result = impute(rowtab, tester.imp(; tester.kwargs...))
+        result = impute(rowtab, tester.imp(; tester.kwargs...))
 
-#         @testset "Base" begin
-#             # Test that we have fewer missing values
-#             @test count(ismissing, Tables.matrix(result)) < count(ismissing, Tables.matrix(rowtab))
-#             @test isa(result, Vector)
+        @testset "Base" begin
+            # Test that we have fewer missing values
+            @test count(ismissing, Tables.matrix(result)) < count(ismissing, Tables.matrix(rowtab))
+            @test isa(result, Vector)
 
-#             # Test that functional form behaves the same way
-#             @test result == tester.f(rowtab; tester.kwargs...)
-#         end
+            # Test that functional form behaves the same way
+            @test result == tester.f(rowtab; tester.kwargs...)
+        end
 
-#         @testset "In-place" begin
-#             # Test that the in-place function return the new results and logs whether it
-#             # successfully did it in-place
-#             rowtab2 = deepcopy(rowtab)
-#             rowtab2_ = tester.f!(rowtab2; tester.kwargs...)
-#             @test rowtab2_ == result
-#             if rowtab2 != result
-#                 @warn "$(tester.f!) did not mutate input data of row table"
-#             end
-#         end
-#     end
-# end
+        @testset "In-place" begin
+            # Test that the in-place function return the new results and logs whether it
+            # successfully did it in-place
+            rowtab2 = deepcopy(rowtab)
+            rowtab2_ = tester.f!(rowtab2; tester.kwargs...)
+            @test rowtab2_ == result
+            if !isequal(rowtab2, result)
+                @warn "$(tester.f!) did not mutate input data of row table"
+            end
+        end
+    end
+end

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -1,0 +1,219 @@
+
+struct ImputorTester{I<:Imputor}
+    imp::Type{I}
+    f::Function
+    f!::Function
+    kwargs::Dict
+end
+
+function ImputorTester(imp::Type{<:Imputor}; kwargs...)
+    fname = lowercase(string(nameof(imp)))
+    settings = Dict(kwargs...)
+    settings[:context] = Context(; limit=1.0)
+
+    return ImputorTester(
+        imp,
+        getfield(Impute, Symbol(fname)),
+        getfield(Impute, Symbol(fname * "!")),
+        settings,
+    )
+end
+
+function test_all(tester::ImputorTester)
+    test_equality(tester)
+    test_vector(tester)
+    test_matrix(tester)
+    test_dataframe(tester)
+end
+
+function test_equality(tester::ImputorTester)
+    @testset "Equality" begin
+        @test tester.imp() == tester.imp()
+    end
+end
+
+function test_vector(tester::ImputorTester)
+    @testset "Vector" begin
+        if tester.imp != DropVars
+            a = allowmissing(1.0:1.0:20.0)
+            a[[2, 3, 7]] .= missing
+
+            result = impute(a, tester.imp(; tester.kwargs...))
+
+            @testset "Base" begin
+                # Test that we have fewer missing values
+                @test count(ismissing, result) < count(ismissing, a)
+                @test isa(result, Vector)
+                @test eltype(result) <: eltype(a)
+
+                # Test that functional form behaves the same way
+                @test result == tester.f(a; tester.kwargs...)
+            end
+
+            @testset "In-place" begin
+                # Test that the in-place function return the new results and logs whether it
+                # successfully did it in-place
+                a2 = deepcopy(a)
+                a2_ = tester.f!(a2; tester.kwargs...)
+                @test a2_ == result
+                if a2 != result
+                    @warn "$(tester.f!) did not mutate input data of type Vector"
+                end
+            end
+
+            @testset "No missing" begin
+                # Test having no missing data
+                b = allowmissing(1.0:1.0:20.0)
+                @test impute(b, tester.imp(; tester.kwargs...)) == b
+            end
+
+            # @testset "All missing" begin
+            #     # Test having only missing data
+            #     c = fill(missing, 10)
+            #     if tester.imp != Impute.DropObs
+            #         @test impute(c, tester.imp(; tester.kwargs...)) == c
+            #     else
+            #         @test impute(c, tester.imp(; tester.kwargs...)) == empty(c)
+            #     end
+            # end
+
+            # @testset "Too many missing values" begin
+            #     # Test Context error condition
+            #     c = fill(missing, 10)
+            #     settings = deepcopy(tester.kwargs)
+            #     settings[:context] = Context(; limit=0.1)
+            #     # @test_throws ImputeError
+            #     impute(c, tester.imp(; settings...))
+            #     # @test_throws ImputeError
+            #     tester.f(c; settings...)
+            # end
+        end
+    end
+end
+
+function test_matrix(tester::ImputorTester)
+    @testset "Matrix" begin
+        a = allowmissing(1.0:1.0:20.0)
+        a[[2, 3, 7]] .= missing
+        m = collect(reshape(a, 5, 4))
+
+        result = impute(m, tester.imp(; tester.kwargs...))
+
+        @testset "Base" begin
+            # Test that we have fewer missing values
+            @test count(ismissing, result) < count(ismissing, m)
+            @test isa(result, Matrix)
+            @test eltype(result) <: eltype(m)
+
+            # Test that functional form behaves the same way
+            @test result == tester.f(m; tester.kwargs...)
+        end
+
+        @testset "In-place" begin
+            # Test that the in-place function return the new results and logs whether it
+            # successfully did it in-place
+            m2 = deepcopy(m)
+            m2_ = tester.f!(m2; tester.kwargs...)
+            @test m2_ == result
+            if m2 != result
+                @warn "$(tester.f!) did not mutate input data of type Matrix"
+            end
+        end
+
+        @testset "No missing" begin
+            # Test having no missing data
+            b = collect(reshape(allowmissing(1.0:1.0:20.0), 5, 4))
+            @test impute(b, tester.imp(; tester.kwargs...)) == b
+        end
+
+        # @testset "All missing" begin
+        #     # Test having only missing data
+        #     c = fill(missing, 5, 2)
+        #     if tester.imp == DropObs
+        #         @test impute(c, tester.imp(; tester.kwargs...)) == Matrix{Missing}(missing, 0, 2)
+        #     elseif tester.imp == DropVars
+        #         @test impute(c, tester.imp(; tester.kwargs...)) == Matrix{Missing}(missing, 5, 0)
+        #     else
+        #         @test impute(c, tester.imp(; tester.kwargs...)) == c
+        #     end
+        # end
+
+        # @testset "Too many missing values" begin
+        #     # Test Context error condition
+        #     c = fill(missing, 5, 2)
+        #     settings = deepcopy(tester.kwargs)
+        #     settings[:context] = Context(; limit=0.1)
+        #     @test_throws ImputeError impute(c, tester.imp(; settings...))
+        #     @test_throws ImputeError tester.f(c; settings...)
+        # end
+    end
+end
+
+function test_dataframe(tester::ImputorTester)
+    @testset "DataFrame" begin
+        table = DataFrame(
+            :sin => allowmissing(sin.(1.0:1.0:20.0)),
+            :cos => allowmissing(sin.(1.0:1.0:20.0)),
+        )
+
+        table.sin[[2, 3, 7, 12, 19]] .= missing
+
+        result = impute(table, tester.imp(; tester.kwargs...))
+
+        @testset "Base" begin
+            # Test that we have fewer missing values
+            @test count(ismissing, Matrix(result)) < count(ismissing, Matrix(table))
+            @test isa(result, DataFrame)
+
+            # Test that functional form behaves the same way
+            @test result == tester.f(table; tester.kwargs...)
+        end
+
+        @testset "In-place" begin
+            # Test that the in-place function return the new results and logs whether it
+            # successfully did it in-place
+            table2 = deepcopy(table)
+            table2_ = tester.f!(table2; tester.kwargs...)
+            @test table2_ == result
+            if table2 != result
+                @warn "$(tester.f!) did not mutate input data of type DataFrame"
+            end
+        end
+
+        @testset "No missing" begin
+            # Test having no missing data
+            b = DataFrame(
+                :sin => allowmissing(sin.(1.0:1.0:20.0)),
+                :cos => allowmissing(sin.(1.0:1.0:20.0)),
+            )
+            @test impute(b, tester.imp(; tester.kwargs...)) == b
+        end
+
+        # @testset "All missing" begin
+        #     # Test having only missing data
+        #     c = DataFrame(
+        #         :sin => fill(missing, 10),
+        #         :cos => fill(missing, 10),
+        #     )
+        #     if tester.imp == DropObs || tester.imp == DropVars
+        #         @test impute(c, tester.imp(; tester.kwargs...)) == DataFrame()
+        #     else
+        #         @test impute(c, tester.imp(; tester.kwargs...)) == c
+        #     end
+        # end
+
+        # @testset "Too many missing values" begin
+        #     # Test Context error condition
+        #     c = DataFrame(
+        #         :sin => fill(missing, 10),
+        #         :cos => fill(missing, 10),
+        #     )
+        #     settings = deepcopy(tester.kwargs)
+        #     settings[:context] = Context(; limit=0.1)
+        #     # @test_throws ImputeError
+        #     impute(c, tester.imp(; settings...))
+        #     # @test_throws ImputeError
+        #     tester.f(c; settings...)
+        # end
+    end
+end


### PR DESCRIPTION
- Use TestSuites to avoid mostly duplicated tests for each Imputor type (closes #46)
- Fixes some error conditions with completely missing datasets (closes #45)
- Fixes ambiguity errors when using rowtables
- Fixes deprecation of GroupedDataFrame broadcasting on 0.19.2

TODO:
- [x] Cleanup existing tests that duplicate behaviour from the testsuites
- ~~[ ] Test chains in the testsuite~~
- [x] Add tests for dataframe groupby