### PR TITLE
Drop global deprecations from package

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Impute"
 uuid = "f7bf1975-0170-51b9-8c5f-a992d46b9575"
 authors = ["Invenia Technical Computing"]
-version = "0.3.0"
+version = "0.4.0"
 
 [deps]
 IterTools = "c8e1da08-722c-5040-9ed9-7db0dc04731e"

--- a/src/Impute.jl
+++ b/src/Impute.jl
@@ -9,25 +9,6 @@ using Tables: Tables, materializer, istable
 import Base.Iterators: drop
 import DataFrames: dropmissing
 
-export impute, impute!, chain, chain!, drop, drop!, interp, interp!, ImputeError
-
-function __init__()
-    sym = join(["chain", "chain!", "drop", "drop!", "interp", "interp!"], ", ", " and ")
-
-    @warn(
-        """
-        The following symbols will not be exported in future releases: $sym.
-        Please qualify your calls with `Impute.<method>(...)` or explicitly import the symbol.
-        """
-    )
-
-    @warn(
-        """
-        The default limit for all impute functions will be 1.0 going forward.
-        If you depend on a specific threshold please pass in an appropriate `AbstractContext`.
-        """
-    )
-end
 
 """
     ImputeError{T} <: Exception

--- a/src/context.jl
+++ b/src/context.jl
@@ -116,7 +116,7 @@ weighted.
 * `on_complete::Function`: a function to run when imputation is complete
 """
 function Context(;
-    limit::Float64=0.1,
+    limit::Float64=1.0,
     is_missing::Function=ismissing,
     on_complete::Function=complete
 )

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ using Statistics
 using StatsBase
 using Random
 
-import Impute:
+using Impute:
     Drop,
     DropObs,
     DropVars,
@@ -20,7 +20,9 @@ import Impute:
     SRS,
     Context,
     WeightedContext,
-    ImputeError
+    ImputeError,
+    interp,
+    chain
 
 
 @testset "Impute" begin


### PR DESCRIPTION
We're just gonna drop some global deprecations during package load time, as they're rather noisy and the change is pretty minimal and has been around for ~6 months.