### PR TITLE
Get impute working with AxisKeys.KeyedArrays

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,6 @@
 environment:
   matrix:
-  - julia_version: 1.0
+  - julia_version: 1.3
   - julia_version: nightly
 
 platform:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - 1.0
+  # 1.0 should also work, but Pkg.test hit some chmod issues on 1.0 in docker containers
+  - 1.3
   - nightly
 notifications:
   email: false

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,8 @@ TableOperations = "ab02a1b2-a7df-11e8-156e-fb1833f50b87"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
-Distances = "0.9"
+AxisKeys = "0.1.5"
+Distances = "0.8, 0.9"
 IterTools = "1.2, 1.3"
 Missings = "0.4"
 NearestNeighbors = "0.4"
@@ -27,6 +28,7 @@ julia = "1"
 
 [extras]
 AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"
+AxisKeys = "94b1ba4f-4ee9-5380-92f1-94cde586c3c5"
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
@@ -35,4 +37,4 @@ RDatasets = "ce6b1742-4840-55fa-b093-852dadbb1d8b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["AxisArrays", "Combinatorics", "DataFrames", "Dates", "Distances", "RDatasets", "Test"]
+test = ["AxisArrays", "AxisKeys", "Combinatorics", "DataFrames", "Dates", "Distances", "RDatasets", "Test"]

--- a/src/imputors/drop.jl
+++ b/src/imputors/drop.jl
@@ -34,6 +34,10 @@ function impute!(data::Vector, imp::DropObs)
     imp.context(c -> filter!(x -> !ismissing!(c, x), data))
 end
 
+function impute!(data::Vector{<:NamedTuple}, imp::DropObs)
+    return materializer(data)(impute(Tables.columns(data), imp))
+end
+
 function impute(data::AbstractVector, imp::DropObs)
     imp.context(c -> filter(x -> !ismissing!(c, x), data))
 end
@@ -95,6 +99,10 @@ end
 # TODO: Switch to using Base.@kwdef on 1.1
 DropVars(; context=Context()) = DropVars(context)
 
+function impute!(data::Vector{<:NamedTuple}, imp::DropVars)
+    return materializer(data)(impute(Tables.columns(data), imp))
+end
+
 function impute(data::AbstractMatrix, imp::DropVars; dims=1)
     imp.context() do c
         return filtervars(data; dims=dims) do vars
@@ -121,10 +129,3 @@ end
 # Add impute! methods to override the default behaviour in imputors.jl
 impute!(data::AbstractMatrix, imp::Union{DropObs, DropVars}) = impute(data, imp)
 impute!(data, imp::Union{DropObs, DropVars}) = impute(data, imp)
-function impute!(data::AbstractVector, imp::Union{DropObs, DropVars})
-    if istable(data)
-        return materializer(data)(impute(Tables.columns(data), imp))
-    else
-        throw(MethodError(impute!, (data, imp)))
-    end
-end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using AxisArrays
+using AxisKeys
 using Combinatorics
 using DataFrames
 using Dates
@@ -482,6 +483,15 @@ end
                 Axis{:row}(1:size(orig, 1)),
                 Axis{:V}(names(orig)),
             )
+            result = Impute.interp(data; context=ctx) |> Impute.locf!() |> Impute.nocb!()
+
+            @test size(result) == size(data)
+            # Confirm that we don't have any more missing values
+            @test all(!ismissing, result)
+        end
+
+        @testset "KeyedArray" begin
+            data = KeyedArray(Matrix(orig); row=1:size(orig, 1), V=names(orig))
             result = Impute.interp(data; context=ctx) |> Impute.locf!() |> Impute.nocb!()
 
             @test size(result) == size(data)


### PR DESCRIPTION
- More strictly handles the row tables special cases (vector that's actually a table). We were previous imputing KeyedArrays as tables because they fit the tables interface... even though we'd typically expect to impute it as an array.