### PR TITLE
Rename `Standardize` to `DeclareMissings`

### DIFF
--- a/docs/src/api/functional.md
+++ b/docs/src/api/functional.md
@@ -37,9 +37,9 @@ Impute.threshold
 Impute.filter
 ```
 
-## Standardize
+## DeclareMissings
 ```@docs
-Impute.standardize
+Impute.declaremissings
 ```
 
 ## Replace

--- a/docs/src/api/imputors.md
+++ b/docs/src/api/imputors.md
@@ -6,10 +6,10 @@ Pages = ["imputors.jl"]
 Order = [:module, :constant, :type, :function]
 ```
 
-## Standardize
+## DeclareMissings
 ```@autodocs
 Modules = [Impute]
-Pages = ["standardize.jl"]
+Pages = ["declaremissings.jl"]
 Order = [:module, :constant, :type, :function]
 ```
 

--- a/docs/src/walkthroughs/svd.md
+++ b/docs/src/walkthroughs/svd.md
@@ -32,7 +32,7 @@ Okay, so as we'd expect there's a reasonable bit of structure we can exploit.
 So how does the svd method compare against other common, yet simpler, methods?
 
 ```@repl svd-example
-data = Impute.standardize(incomplete; values=-1.0)
+data = Impute.declaremissings(incomplete; values=-1.0)
 
 # NOTE: SVD performance is almost identical regardless of the `init` setting.
 imputors = [

--- a/src/functional.jl
+++ b/src/functional.jl
@@ -49,7 +49,7 @@ const global imputation_methods = (
     nocb = NOCB,
     replace = Replace,
     srs = SRS,
-    standardize = Standardize,
+    declaremissings = DeclareMissings,
     substitute = Substitute,
     svd = SVD,
     knn = KNN,
@@ -400,9 +400,9 @@ julia> Impute.srs(df; rng=MersenneTwister(1234))
 """ srs
 
 @doc """
-    Impute.standardize(data; values)
+    Impute.declaremissings(data; values)
 
-Standardize (or replace) various missing data representations with `missing`.
+DeclareMissings (or replace) various missing data representations with `missing`.
 
 # Keyword Arguments
 * `value::Tuple`: A tuple of values that should be considered `missing`
@@ -426,7 +426,7 @@ julia> df = DataFrame(
 │ 4   │ NaN     │ -9999 │ y      │
 │ 5   │ 5.5     │ 5     │ NULL   │
 
-julia> Impute.standardize(df; values=(NaN, -9999, "NULL"))
+julia> Impute.declaremissings(df; values=(NaN, -9999, "NULL"))
 5×3 DataFrame
 │ Row │ a        │ b       │ c       │
 │     │ Float64? │ Int64?  │ String? │
@@ -437,7 +437,7 @@ julia> Impute.standardize(df; values=(NaN, -9999, "NULL"))
 │ 4   │ missing  │ missing │ y       │
 │ 5   │ 5.5      │ 5       │ missing │
 ```
-""" standardize
+""" declaremissings
 
 @doc """
     Impute.substitute(data; statistic=nothing)

--- a/src/imputors.jl
+++ b/src/imputors.jl
@@ -241,7 +241,7 @@ files = [
     "nocb.jl",
     "replace.jl",
     "srs.jl",
-    "standardize.jl",
+    "declaremissings.jl",
     "substitute.jl",
     "svd.jl",
 ]

--- a/test/imputors/declaremissings.jl
+++ b/test/imputors/declaremissings.jl
@@ -1,9 +1,9 @@
-# The standardize imputor is sufficiently different in its input and behaviour
+# The declaremissings imputor is sufficiently different in its input and behaviour
 # that we don't bother using the ImputorTester here.
-@testset "Standardize" begin
+@testset "DeclareMissings" begin
     # List a couple known missing data values people might use.
     values = (NaN, 0.0, Nothing, "", 9999, -99, 0, DateTime(0))
-    imp = Standardize(; values=values)
+    imp = DeclareMissings(; values=values)
 
     @testset "Vector" begin
         @testset "disallowmissing" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,7 +29,7 @@ using Impute:
     NOCB,
     Replace,
     SRS,
-    Standardize,
+    DeclareMissings,
     Substitute,
     SVD,
     Filter,
@@ -58,7 +58,7 @@ using Impute:
     include("imputors/nocb.jl")
     include("imputors/replace.jl")
     include("imputors/srs.jl")
-    include("imputors/standardize.jl")
+    include("imputors/declaremissings.jl")
     include("imputors/substitute.jl")
     include("imputors/svd.jl")
     include("utils.jl")


### PR DESCRIPTION
This minimizes confusion with other types of standardization (e.g., z-scores) and more closely aligns with existing missing functions (e.g., `allowmissing`, `disallowmissing`, `skipmissings`).

Closes #76