### PR TITLE
DeclareMissings is not a real Imputor

### DIFF
--- a/src/Impute.jl
+++ b/src/Impute.jl
@@ -19,6 +19,7 @@ using LinearAlgebra
 using LinearAlgebra: Diagonal
 
 include("utils.jl")
+include("declaremissings.jl")
 include("imputors.jl")
 include("filter.jl")
 include("validators.jl")

--- a/src/chain.jl
+++ b/src/chain.jl
@@ -1,4 +1,5 @@
-const Transform = Union{Validator, Filter, Imputor}
+# This should maybe be a supertype at some point?
+const Transform = Union{Validator, DeclareMissings, Filter, Imputor}
 
 """
     Chain{T<:Tuple{Vararg{Transform}}} <: Function
@@ -69,6 +70,9 @@ function (C::Chain)(data; kwargs...)
         if isa(t, Validator)
             # Validators just return the input
             validate(X, t; kwargs...)
+        elseif isa(t, DeclareMissings)
+            # DeclareMissings isn't guaranteed to work in-place
+            X = apply(X, t)
         elseif isa(t, Filter)
             # Filtering doesn't always work in-place
             X = apply(X, t; kwargs...)

--- a/src/functional.jl
+++ b/src/functional.jl
@@ -49,7 +49,6 @@ const global imputation_methods = (
     nocb = NOCB,
     replace = Replace,
     srs = SRS,
-    declaremissings = DeclareMissings,
     substitute = Substitute,
     svd = SVD,
     knn = KNN,
@@ -82,6 +81,9 @@ for (func, type) in pairs(imputation_methods)
         @deprecate $func!(; kwargs...) data -> $func!(data; kwargs...) false
     end
 end
+
+declaremissings(data; kwargs...) = apply(data, DeclareMissings(; kwargs...))
+declaremissings!(data; kwargs...) = apply!(data, DeclareMissings(; kwargs...))
 
 # Provide a specific functional API for Impute.Filter.
 filter(data; kwargs...) = apply(data, Filter(); kwargs...)

--- a/src/imputors.jl
+++ b/src/imputors.jl
@@ -241,7 +241,6 @@ files = [
     "nocb.jl",
     "replace.jl",
     "srs.jl",
-    "declaremissings.jl",
     "substitute.jl",
     "svd.jl",
 ]

--- a/test/chain.jl
+++ b/test/chain.jl
@@ -110,6 +110,7 @@
         # Filter out colunns with more than 400 missing values, Fill with 0, and check that
         # everything was replaced
         C = Chain(
+            Impute.DeclareMissings(; values=(NaN, Inf, -Inf)),
             Impute.Filter(c -> count(ismissing, c) < 400),
             Impute.Replace(; values=0.0),
             Impute.Threshold(),

--- a/test/declaremissings.jl
+++ b/test/declaremissings.jl
@@ -32,6 +32,11 @@
             result2 = apply!(b, imp)
             @test eltype(result2) == Union{Float64, Missing}
             @test all(ismissing, result2[[2, 3, 7]])
+
+            c = copy(a)
+            result3 = Impute.declaremissings!(c; values=values)
+            @test eltype(result3) == Union{Float64, Missing}
+            @test all(ismissing, result3[[2, 3, 7]])
         end
 
         @testset "All missing" begin

--- a/test/declaremissings.jl
+++ b/test/declaremissings.jl
@@ -10,28 +10,26 @@
             a = collect(1.0:1.0:20.0)
             a[[2, 3, 7]] .= [NaN, 0.0, NaN]
 
-            result = impute(a, imp)
+            result = apply(a, imp)
             @test eltype(result) == Union{Float64, Missing}
             @test all(ismissing, result[[2, 3, 7]])
 
             # In-place operation don't work when the source array doesn't allow missings.
             b = copy(a)
-            result2 = impute!(b, imp)
-            @test eltype(result2) == Float64
-            @test isequal(result2[[2, 3, 7]], [NaN, 0.0, NaN])
+            @test_throws MethodError apply!(b, imp)
         end
 
         @testset "allowmissing" begin
             a = allowmissing(collect(1.0:1.0:20.0))
             a[[2, 3, 7]] .= [NaN, 0.0, NaN]
 
-            result = impute(a, imp)
+            result = apply(a, imp)
             @test eltype(result) == Union{Float64, Missing}
             @test all(ismissing, result[[2, 3, 7]])
 
-            # In-place operation don't work when the source array doesn't allow missings.
+            # In-place operation work when the source array allows missings.
             b = copy(a)
-            result2 = impute!(b, imp)
+            result2 = apply!(b, imp)
             @test eltype(result2) == Union{Float64, Missing}
             @test all(ismissing, result2[[2, 3, 7]])
         end
@@ -39,7 +37,7 @@
         @testset "All missing" begin
             # Test having only missing data
             c = fill(missing, 10)
-            @test isequal(impute(c, imp), c)
+            @test isequal(apply(c, imp), c)
         end
     end
 
@@ -49,15 +47,13 @@
             a[[2, 3, 7]] .= [NaN, 0.0, NaN]
             m = collect(reshape(a, 5, 4))
 
-            result = impute(m, imp)
+            result = apply(m, imp)
             @test eltype(result) == Union{Float64, Missing}
             @test all(ismissing, result[[2, 3, 7]])
 
             # In-place operation don't work when the source array doesn't allow missings.
             n = copy(m)
-            result2 = impute!(n, imp)
-            @test eltype(result2) == Float64
-            @test isequal(result2[[2, 3, 7]], [NaN, 0.0, NaN])
+            @test_throws MethodError apply!(n, imp)
         end
 
         @testset "allowmissing" begin
@@ -65,13 +61,13 @@
             a[[2, 3, 7]] .= [NaN, 0.0, NaN]
             m = collect(reshape(a, 5, 4))
 
-            result = impute(m, imp)
+            result = apply(m, imp)
             @test eltype(result) == Union{Float64, Missing}
             @test all(ismissing, result[[2, 3, 7]])
 
             # In-place operation don't work when the source array doesn't allow missings.
             n = copy(m)
-            result2 = impute!(n, imp)
+            result2 = apply!(n, imp)
             @test eltype(result2) == Union{Float64, Missing}
             @test all(ismissing, result2[[2, 3, 7]])
         end
@@ -79,7 +75,7 @@
         @testset "All missing" begin
             # Test having only missing data
             c = fill(missing, 5, 4)
-            @test isequal(impute(c, imp), c)
+            @test isequal(apply(c, imp), c)
         end
     end
     @testset "Tables" begin
@@ -106,21 +102,8 @@
                 :desc => ["foo", "bar", missing],
             )
 
-            @testset "disallowmissing" begin
-                result = impute(table, imp)
-                @test isequal(result, expected)
-
-                result2 = impute!(deepcopy(table), imp)
-                @test !isequal(result2, expected)
-            end
-
-            @testset "allowmissing" begin
-                result = impute(mtable, imp)
-                @test isequal(result, expected)
-
-                result2 = impute!(deepcopy(mtable), imp)
-                @test isequal(result2, expected)
-            end
+            result = apply(table, imp)
+            @test isequal(result, expected)
         end
 
         @testset "Column Table" begin
@@ -146,21 +129,8 @@
                 desc = ["foo", "bar", missing],
             )
 
-            @testset "disallowmissing" begin
-                result = impute(table, imp)
-                @test isequal(result, expected)
-
-                result2 = impute!(deepcopy(table), imp)
-                @test !isequal(result2, expected)
-            end
-
-            @testset "allowmissing" begin
-                result = impute(mtable, imp)
-                @test isequal(result, expected)
-
-                result2 = impute!(deepcopy(mtable), imp)
-                @test isequal(result2, expected)
-            end
+            result = apply(table, imp)
+            @test isequal(result, expected)
         end
 
         @testset "Row Table" begin
@@ -186,21 +156,8 @@
                 desc = ["foo", "bar", missing],
             ))
 
-            @testset "disallowmissing" begin
-                result = impute(table, imp)
-                @test isequal(result, expected)
-
-                result2 = impute!(deepcopy(table), imp)
-                @test !isequal(result2, expected)
-            end
-
-            @testset "allowmissing" begin
-                result = impute(mtable, imp)
-                @test isequal(result, expected)
-
-                result2 = impute!(deepcopy(mtable), imp)
-                @test isequal(result2, expected)
-            end
+            result = apply(table, imp)
+            @test isequal(result, expected)
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,6 +36,7 @@ using Impute:
     Threshold,
     ThresholdError,
     apply,
+    apply!,
     impute,
     impute!,
     interp,
@@ -48,6 +49,7 @@ using Impute:
     include("testutils.jl")
 
     include("validators.jl")
+    include("declaremissings.jl")
     include("chain.jl")
     include("data.jl")
     include("deprecated.jl")
@@ -58,7 +60,6 @@ using Impute:
     include("imputors/nocb.jl")
     include("imputors/replace.jl")
     include("imputors/srs.jl")
-    include("imputors/declaremissings.jl")
     include("imputors/substitute.jl")
     include("imputors/svd.jl")
     include("utils.jl")


### PR DESCRIPTION
1. It often won't return the input data type if the input data doesn't allowmissings.
2. The API is sufficiently different in that it doesn't really apply across dimensions like the other imputors.
3. It's actively making more `missing`s rather than estimating realistic values which puts it closer to the Filter method than a a real imputor.

Closes #77 