### PR TITLE
Separate weighted types

### DIFF
--- a/src/functional.jl
+++ b/src/functional.jl
@@ -52,6 +52,7 @@ const global imputation_methods = (
     srs = SRS,
     declaremissings = DeclareMissings,
     substitute = Substitute,
+    wsubstitute = WeightedSubstitute,
     svd = SVD,
     knn = KNN,
 )

--- a/src/functional.jl
+++ b/src/functional.jl
@@ -37,6 +37,7 @@ end
 
 const global validation_methods = (
     threshold = Threshold,
+    wthreshold = WeightedThreshold,
 )
 
 const global imputation_methods = (
@@ -90,9 +91,9 @@ filter(f::Function, data; kwargs...) = apply(data, Filter(f); kwargs...)
 filter!(f::Function, data; kwargs...) = apply!(data, Filter(f); kwargs...)
 
 @doc """
-    Impute.threshold(data; ratio=0.1, weights=nothing, kwargs...)
+    Impute.threshold(data; limit=0.1, kwargs...)
 
-Assert that proportion of missing values in the `data` do not exceed the `ratio`.
+Assert that proportion of missing values in the `data` do not exceed the `limit`.
 
 # Examples
 ```julia-repl
@@ -110,11 +111,11 @@ julia> df = DataFrame(:a => [1.0, 2.0, missing, missing, 5.0], :b => [1.1, 2.2, 
 │ 5   │ 5.0      │ 5.5      │
 
 julia> Impute.threshold(df)
-ERROR: ThresholdError: Ratio of missing values exceeded 0.1 (0.4)
+ERROR: ThresholdError: Missing data limit exceeded 0.1 (0.4)
 Stacktrace:
 ...
 
-julia> Impute.threshold(df; ratio=0.8)
+julia> Impute.threshold(df; limit=0.8)
 5×2 DataFrames.DataFrame
 │ Row │ a        │ b        │
 │     │ Float64  │ Float64  │
@@ -127,6 +128,45 @@ julia> Impute.threshold(df; ratio=0.8)
 ```
 """
 threshold
+
+@doc """
+    Impute.wthreshold(data; ratio, weights, kwargs...)
+
+Assert that the weighted proportion of missing values in the `data` do not exceed the `limit`.
+
+# Examples
+```julia-repl
+julia> using DataFrames, Impute
+
+julia> df = DataFrame(:a => [1.0, 2.0, missing, missing, 5.0], :b => [1.1, 2.2, 3.3, missing, 5.5])
+5×2 DataFrames.DataFrame
+│ Row │ a        │ b        │
+│     │ Float64  │ Float64  │
+├─────┼──────────┼──────────┤
+│ 1   │ 1.0      │ 1.1      │
+│ 2   │ 2.0      │ 2.2      │
+│ 3   │ missing  │ 3.3      │
+│ 4   │ missing  │ missing  │
+│ 5   │ 5.0      │ 5.5      │
+
+julia> Impute.wthreshold(df; limit=0.4, weights=0.1:0.1:0.5)
+ERROR: ThresholdError: Missing data limit exceeded 0.4 (0.4666666666666666)
+Stacktrace:
+...
+
+julia> Impute.wthreshold(df; limit=0.4, weights=0.5:-0.1:0.1)
+5×2 DataFrames.DataFrame
+│ Row │ a        │ b        │
+│     │ Float64  │ Float64  │
+├─────┼──────────┼──────────┤
+│ 1   │ 1.0      │ 1.1      │
+│ 2   │ 2.0      │ 2.2      │
+│ 3   │ missing  │ 3.3      │
+│ 4   │ missing  │ missing  │
+│ 5   │ 5.0      │ 5.5      │
+```
+"""
+wthreshold
 
 @doc """
     Impute.dropobs(data; dims=1)

--- a/src/imputors/substitute.jl
+++ b/src/imputors/substitute.jl
@@ -1,24 +1,13 @@
 """
-    Substitute(; statistic=nothing)
-    Substitute(; robust=true, weights=nothing)
+    Substitute(; statistic=Impute.defaultstats)
 
 Substitute missing values with a summary statistic over the non-missing values.
 
 # Keyword Arguments
 * `statistic`: A summary statistic function to be applied to the non-missing values.
   This function should return a value of the same type as the input data `eltype`.
-  If this function isn't passed in then the `defaultstats` function is used to make a
-  best guess.
-* `robust`: Whether to use `median` or `mean` for continuous datasets in `defaultstats`
-* `weights`: A set of statistical weights to apply to the `mean` or `median` in `defaultstats`.
-
-# Default Rules
-Our default substitution rules defined in `defaultstats` are as follows:
-
-* `mode` applies to non-`Real`s, `Bool`s, and `Integers` with few unique values.
-* `median` is used for all other `Real` values that aren't restricted by the above rules.
-  Optionally, `mean` can be used if `robust=false`. If statistical `weights` are passed in
-  then a weighted `mean`/`median` will be calculated.
+  If this function isn't passed in then the [`defaultstats`](@ref) function is used to make
+  a best guess.
 
 # Example
 ```jldoctest
@@ -29,61 +18,108 @@ julia> M = [1.0 2.0 missing missing 5.0; 1.1 2.2 3.3 missing 5.5]
  1.0  2.0   missing  missing  5.0
  1.1  2.2  3.3       missing  5.5
 
-julia> impute(M, Substitute(; statistic=mean ∘ skipmissing); dims=:rows)
+julia> impute(M, Substitute(); dims=:rows)
+2×5 Array{Union{Missing, Float64},2}:
+ 1.0  2.0  2.0  2.0   5.0
+ 1.1  2.2  3.3  2.75  5.5
+
+julia> impute(M, Substitute(; statistic=mean); dims=:rows)
 2×5 Array{Union{Missing, Float64},2}:
  1.0  2.0  2.66667  2.66667  5.0
  1.1  2.2  3.3      3.025    5.5
 ```
 """
-struct Substitute <: Imputor
-    statistic::Function
+struct Substitute{F<:Function} <: Imputor
+    statistic::F
 end
 
-function Substitute(;
-    statistic::Union{Function, Nothing}=nothing,
-    robust=true,
-    weights=nothing
-)
-    statistic !== nothing && return Substitute(statistic)
-
-    return Substitute() do data
-        if weights === nothing
-            items = collect(skipmissing(data))
-            defaultstats(items, robust)
-        else
-            mask = .!ismissing.(data)
-            items = disallowmissing(data[mask])
-            wv = weights[mask]
-            defaultstats(items, robust, wv)
-        end
-    end
-end
+Substitute(; statistic=defaultstats) = Substitute(statistic)
 
 function _impute!(data::AbstractArray{Union{T, Missing}}, imp::Substitute) where T
-    x = imp.statistic(data)
+    mask = .!ismissing.(data)
+    x = imp.statistic(disallowmissing(data[mask]))
+    return Base.replace!(data, missing => x)
+end
+
+
+"""
+    WeightedSubstitute(; statistic=Impute.defaultstats, weights)
+
+Substitute missing values with a weighted summary statistic over the non-missing values.
+
+# Keyword Arguments
+* `statistic`: A summary statistic function to be applied to the non-missing values.
+  This function should return a value of the same type as the input data `eltype`.
+  If this function isn't passed in then the [`defaultstats`](@ref) function is used to make
+  a best guess.
+* `weights`: A set of statistical weights to pass to the `statistic` function.
+
+# Example
+```jldoctest
+julia> using Statistics, StatsBase; using Impute: WeightedSubstitute, impute
+
+julia> M = [1.0 2.0 missing missing 5.0; 1.1 2.2 3.3 missing 5.5]
+2×5 Array{Union{Missing, Float64},2}:
+ 1.0  2.0   missing  missing  5.0
+ 1.1  2.2  3.3       missing  5.5
+
+julia> wv = weights([0.5, 0.2, 0.3, 0.1, 0.4]);
+
+julia> impute(M, WeightedSubstitute(; weights=wv); dims=:rows)
+2×5 Array{Union{Missing, Float64},2}:
+ 1.0  2.0  2.75  2.75     5.0
+ 1.1  2.2  3.3   3.11667  5.5
+```
+"""
+struct WeightedSubstitute{F<:Function, W<:AbstractArray{<:Real}} <: Imputor
+    statistic::F
+    weights::W
+end
+
+function WeightedSubstitute(; statistic=defaultstats, weights)
+    return WeightedSubstitute(statistic, weights)
+end
+
+function _impute!(data::AbstractArray{Union{T, Missing}}, imp::WeightedSubstitute) where T
+    mask = .!ismissing.(data)
+    x = imp.statistic(disallowmissing(data[mask]), imp.weights[mask])
     return Base.replace!(data, missing => x)
 end
 
 # Auxiliary functions defining our default substitution rules
 
+@doc """
+    defaultstats(data[, wv])
+
+A set of default substitution rules using either `median` or `mode` based on the `eltype` of
+the input `data`. Specific rules are summarized as follows.
+
+* `Bool` elements use `mode`
+* `Real` elements use `median`
+* `Integer` elements where `nunique(data) / length(data) < 0.25` use `mode`
+  (ratings, categorical codings, etc)
+* `Integer` elements with mostly unique values use `median`
+* `!Number` (non-numeric) elements use `mode` as the safest fallback
+""" defaultstats
+
 # If we're operating over Bools then we're probably better off using mode
-defaultstats(data::AbstractArray{<:Bool}, robust::Bool, args...) = mode(data)
+defaultstats(data::AbstractArray{<:Bool}, args...) = _mode(data, args...)
+
+# If we're operating over Reals then we should probably use the median
+defaultstats(data::AbstractArray{<:Real}, args...) = median(data, args...)
 
 # If we're operating over integers with relatively few unique values then we're
 # likely dealing with either counts or a categorical coding, so mode is probably
 # safer
-function defaultstats(data::AbstractArray{T}, robust::Bool, args...) where T <: Integer
+function defaultstats(data::AbstractArray{T}, args...) where T <: Integer
     threshold = 0.25 * length(data)
     nunique = length(unique(data))
-    nunique < threshold && return mode(data)
-    result = robust ? median(data, args...) : mean(data, args...)
-    return round(T, result)
-end
-
-# For most real valued data we should use median
-function defaultstats(data::AbstractArray{<:Real}, robust::Bool, args...)
-    return robust ? median(data, args...) : mean(data, args...)
+    if nunique < threshold
+        return _mode(data, args...)
+    else
+        return round(T, median(data, args...))
+    end
 end
 
 # Fallback to mode as many types won't support mean or median anyways
-defaultstats(data::AbstractArray, args...) = mode(data)
+defaultstats(data::AbstractArray, args...) = _mode(data, args...)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -26,3 +26,29 @@ function dim(data, d)
         return NamedDims.dim(NamedDims.dimnames(data), d)
     end
 end
+
+# Remove this once the corresponding statsbase pull request is merged and tagged.
+# https://github.com/JuliaStats/StatsBase.jl/pull/611
+_mode(a::AbstractArray) = mode(a)
+
+function _mode(a::AbstractVector, wv::AbstractArray{T}) where T <: Real
+    isempty(a) && throw(ArgumentError("mode is not defined for empty collections"))
+    length(a) == length(wv) || throw(ArgumentError(
+        "data and weight vectors must be the same size, got $(length(a)) and $(length(wv))"
+    ))
+
+    # Iterate through the data
+    mv = first(a)
+    mw = first(wv)
+    weights = Dict{eltype(a), T}()
+    for (x, w) in zip(a, wv)
+        _w = get!(weights, x, zero(T)) + w
+        if _w > mw
+            mv = x
+            mw = _w
+        end
+        weights[x] = _w
+    end
+
+    return mv
+end

--- a/test/imputors/substitute.jl
+++ b/test/imputors/substitute.jl
@@ -3,105 +3,86 @@
         test_all(ImputorTester(Substitute))
     end
 
-    @testset "defaultstats" begin
-        @testset "robust" begin
-            # Defining our missing datasets
-            a = allowmissing(1.0:1.0:20.0)
-            a[[2, 3, 7]] .= missing
-            fill_val = median(skipmissing(a))
+    @testset "reals" begin
+        # Defining our missing datasets
+        a = allowmissing(1.0:1.0:20.0)
+        a[[2, 3, 7]] .= missing
+        fill_val = median(skipmissing(a))
 
-            result = impute(a, Substitute())
-            expected = copy(a)
-            expected[[2, 3, 7]] .= fill_val
+        result = impute(a, Substitute())
+        expected = copy(a)
+        expected[[2, 3, 7]] .= fill_val
 
-            @test result == expected
-            @test result == Impute.substitute(a)
-        end
+        @test result == expected
+        @test result == Impute.substitute(a)
+    end
 
-        @testset "weighted" begin
-            # Defining our missing datasets
-            a = allowmissing(1.0:1.0:20.0)
-            wv = eweights(20, 0.3)
-            a[[2, 3, 7]] .= missing
-            mask = .!ismissing.(a)
+    @testset "counts" begin
+        a = allowmissing([1, 12, 4, 6, 2, 5, 9, 19, 24, 35, 44, 99])
+        a[[2, 3, 7]] .= missing
 
-            fill_val = mean(a[mask], wv[mask])
+        # We should default to taking the  median because otherwise `mode` will
+        # just return `1`
+        fill_val = round(Int, median(skipmissing(a)))
 
-            result = impute(a, Substitute(; robust=false, weights=wv))
-            expected = copy(a)
-            expected[[2, 3, 7]] .= fill_val
+        result = impute(a, Substitute())
+        expected = copy(a)
+        expected[[2, 3, 7]] .= fill_val
 
-            @test result == expected
-            @test result == Impute.substitute(a; robust=false, weights=wv)
-        end
+        @test result == expected
+        @test result == Impute.substitute(a)
+    end
 
-        @testset "counts" begin
-            a = allowmissing([1, 12, 4, 6, 2, 5, 9, 19, 24, 35, 44, 99])
-            a[[2, 3, 7]] .= missing
+    @testset "ratings" begin
+        # Slightly imbalanced ratings
+        a = allowmissing(vcat(repeat(1:5, 5), [1, 1, 5]))
+        a[[2, 3, 7]] .= missing
 
-            # We should default to taking the  median because otherwise `mode` will
-            # just return `1`
-            fill_val = round(Int, median(skipmissing(a)))
+        # We likely want to the mode because we only have a few unique values.
+        fill_val = mode(skipmissing(a))
+        @test fill_val == 1
 
-            result = impute(a, Substitute())
-            expected = copy(a)
-            expected[[2, 3, 7]] .= fill_val
+        result = impute(a, Substitute())
+        expected = copy(a)
+        expected[[2, 3, 7]] .= fill_val
 
-            @test result == expected
-            @test result == Impute.substitute(a)
-        end
+        @test result == expected
+        @test result == Impute.substitute(a)
+    end
 
-        @testset "ratings" begin
-            # Slightly imbalanced ratings
-            a = allowmissing(vcat(repeat(1:5, 5), [1, 1, 5]))
-            a[[2, 3, 7]] .= missing
+    @testset "bools" begin
+        a = allowmissing(vcat(falses(14), trues(6)))
+        a[[2, 3, 7]] .= missing
 
-            # We likely want to the mode because we only have a few unique values.
-            fill_val = mode(skipmissing(a))
-            @test fill_val == 1
+        # For the same reason as for ratings we should probably just use the mode.
+        # Though most of the time they'll give the same answer once rounded.
+        fill_val = mode(skipmissing(a))
+        @test fill_val == false
 
-            result = impute(a, Substitute())
-            expected = copy(a)
-            expected[[2, 3, 7]] .= fill_val
+        result = impute(a, Substitute())
+        expected = copy(a)
+        expected[[2, 3, 7]] .= fill_val
 
-            @test result == expected
-            @test result == Impute.substitute(a)
-        end
+        @test result == expected
+        @test result == Impute.substitute(a)
+    end
 
-        @testset "bools" begin
-            a = allowmissing(vcat(falses(14), trues(6)))
-            a[[2, 3, 7]] .= missing
+    @testset "non-real" begin
+        a = allowmissing(DateTime(2000, 1, 1):Day(1):DateTime(2000, 1, 20))
+        a[[2, 3, 7]] .= missing
 
-            # For the same reason as for ratings we should probably just use the mode.
-            # Though most of the time they'll give the same answer once rounded.
-            fill_val = mode(skipmissing(a))
-            @test fill_val == false
+        # Median of `DateTime`s doesn't apply, so we fallback to `mode`
+        fill_val = mode(skipmissing(a))
 
-            result = impute(a, Substitute())
-            expected = copy(a)
-            expected[[2, 3, 7]] .= fill_val
+        # In this case that's just going to take the first observation it finds
+        fill_val == DateTime(2000, 1, 1)
 
-            @test result == expected
-            @test result == Impute.substitute(a)
-        end
+        result = impute(a, Substitute())
+        expected = copy(a)
+        expected[[2, 3, 7]] .= fill_val
 
-        @testset "non-real" begin
-            a = allowmissing(DateTime(2000, 1, 1):Day(1):DateTime(2000, 1, 20))
-            a[[2, 3, 7]] .= missing
-
-            # Median of `DateTime`s doesn't apply, so we fallback to `mode`
-            fill_val = mode(skipmissing(a))
-
-            # In this case that's just going to take the first observation it finds
-            fill_val == DateTime(2000, 1, 1)
-
-            result = impute(a, Substitute())
-            expected = copy(a)
-            expected[[2, 3, 7]] .= fill_val
-
-            @test result == expected
-            @test result == Impute.substitute(a)
-        end
+        @test result == expected
+        @test result == Impute.substitute(a)
     end
 
     @testset "custom statistic" begin
@@ -117,7 +98,125 @@
         expected[[2, 3, 7]] .= fill_val
         result = Impute.substitute(
             a;
-            statistic=data -> -(mean_and_std(skipmissing(data))...)
+            statistic=data -> -(mean_and_std(data)...)
+        )
+        @test result == expected
+    end
+end
+
+@testset "WeightedSubstitute" begin
+    # Don't worry about the default tests since the weights are too coupled to the data.
+    @testset "reals" begin
+        # Defining our missing datasets
+        a = allowmissing(1.0:1.0:20.0)
+        wv = eweights(20, 0.3)
+        mask = trues(20)
+        mask[[2, 3, 7]] .= false
+        a[[2, 3, 7]] .= missing
+
+        fill_val = median(disallowmissing(a[mask]), wv[mask])
+
+        result = impute(a, WeightedSubstitute(; weights=wv))
+        expected = copy(a)
+        expected[[2, 3, 7]] .= fill_val
+
+        @test result == expected
+        @test result == Impute.wsubstitute(a; weights=wv)
+    end
+
+    @testset "counts" begin
+        a = allowmissing([1, 12, 4, 6, 2, 5, 9, 19, 24, 35, 44, 99])
+        wv = eweights(12, 0.3)
+        mask = trues(12)
+        mask[[2, 3, 7]] .= false
+        a[[2, 3, 7]] .= missing
+
+        # We should default to taking the  median because otherwise `mode` will
+        # just return `1`
+        fill_val = round(Int, median(disallowmissing(a[mask]), wv[mask]))
+
+        result = impute(a, WeightedSubstitute(; weights=wv))
+        expected = copy(a)
+        expected[[2, 3, 7]] .= fill_val
+
+        @test result == expected
+        @test result == Impute.wsubstitute(a; weights=wv)
+    end
+
+    @testset "ratings" begin
+        # Slightly imbalanced ratings
+        a = allowmissing(vcat(repeat(1:5, 5), [1, 1, 5]))
+        wv = eweights(28, 0.3)
+        mask = trues(28)
+        mask[[2, 3, 7]] .= false
+        a[[2, 3, 7]] .= missing
+
+        # We likely want to the mode because we only have a few unique values.
+        fill_val = Impute._mode(a[mask], wv[mask])
+
+        result = impute(a, WeightedSubstitute(; weights=wv))
+        expected = copy(a)
+        expected[[2, 3, 7]] .= fill_val
+
+        @test result == expected
+        @test result == Impute.wsubstitute(a; weights=wv)
+    end
+
+    @testset "bools" begin
+        a = allowmissing(vcat(falses(14), trues(6)))
+        wv = eweights(20, 0.3)
+        mask = trues(20)
+        mask[[2, 3, 7]] .= false
+        a[[2, 3, 7]] .= missing
+
+        # For the same reason as for ratings we should probably just use the mode.
+        # Though most of the time they'll give the same answer once rounded.
+        fill_val = Impute._mode(a[mask], wv[mask])
+
+        result = impute(a, WeightedSubstitute(; weights=wv))
+        expected = copy(a)
+        expected[[2, 3, 7]] .= fill_val
+
+        @test result == expected
+        @test result == Impute.wsubstitute(a; weights=wv)
+    end
+
+    @testset "non-real" begin
+        a = allowmissing(DateTime(2000, 1, 1):Day(1):DateTime(2000, 1, 20))
+        wv = eweights(20, 0.3)
+        mask = trues(20)
+        mask[[2, 3, 7]] .= false
+        a[[2, 3, 7]] .= missing
+
+        # Median of `DateTime`s doesn't apply, so we fallback to `mode`
+        fill_val = Impute._mode(a[mask], wv[mask])
+
+        result = impute(a, WeightedSubstitute(; weights=wv))
+        expected = copy(a)
+        expected[[2, 3, 7]] .= fill_val
+
+        @test result == expected
+        @test result == Impute.wsubstitute(a; weights=wv)
+    end
+
+    @testset "custom statistic" begin
+        # Defining our missing datasets
+        a = allowmissing(1.0:1.0:20.0)
+        wv = eweights(20, 0.3)
+        mask = trues(20)
+        mask[[2, 3, 7]] .= false
+        a[[2, 3, 7]] .= missing
+
+        # We'll do mean - 1 std for some reason :)
+        μ, σ = mean_and_std(disallowmissing(a[mask]), wv[mask])
+        fill_val = μ - σ
+
+        expected = copy(a)
+        expected[[2, 3, 7]] .= fill_val
+        result = Impute.wsubstitute(
+            a;
+            statistic=(data, weights) -> -(mean_and_std(data, weights)...),
+            weights=wv
         )
         @test result == expected
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,6 +34,7 @@ using Impute:
     SVD,
     Filter,
     Threshold,
+    WeightedThreshold,
     ThresholdError,
     apply,
     impute,
@@ -41,6 +42,7 @@ using Impute:
     interp,
     run,
     threshold,
+    wthreshold,
     validate
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,6 +31,7 @@ using Impute:
     SRS,
     DeclareMissings,
     Substitute,
+    WeightedSubstitute,
     SVD,
     Filter,
     Threshold,

--- a/test/validators.jl
+++ b/test/validators.jl
@@ -21,7 +21,7 @@
     table.sin[[2, 3, 7, 12, 19]] .= missing
 
     @testset "Base" begin
-        t = Threshold(; ratio=0.1)
+        t = Threshold(; limit=0.1)
         @test_throws ThresholdError validate(a, t)
         @test_throws ThresholdError validate(m, t)
         @test_throws ThresholdError validate(aa, t)
@@ -34,9 +34,9 @@
             sprint(showerror, e)
         end
 
-        @test msg == "ThresholdError: Ratio of missing values exceeded 0.1 (0.15)\n"
+        @test msg == "ThresholdError: Missing data limit exceeded 0.1 (0.15)\n"
 
-        t = Threshold(; ratio=0.8)
+        t = Threshold(; limit=0.8)
         # Use isequal because we expect the results to contain missings
         @test isequal(validate(a, t), a)
         @test isequal(validate(m, t), m)
@@ -47,20 +47,20 @@
     @testset "Weighted" begin
         # If we use an exponentially weighted context then we won't pass the limit
         # because missing earlier observations is less important than later ones.
-        t = Threshold(; ratio=0.8, weights=eweights(20, 0.3))
+        t = WeightedThreshold(; limit=0.8, weights=eweights(20, 0.3))
         @test isequal(validate(a, t), a)
         @test isequal(validate(table, t), table)
 
-        @test isequal(threshold(m; ratio=0.8, weights=eweights(5, 0.3), dims=:cols), m)
-        @test isequal(threshold(m; ratio=0.8, weights=eweights(5, 0.3), dims=:cols), aa)
+        @test isequal(wthreshold(m; limit=0.8, weights=eweights(5, 0.3), dims=:cols), m)
+        @test isequal(wthreshold(m; limit=0.8, weights=eweights(5, 0.3), dims=:cols), aa)
 
         # If we reverse the weights such that earlier observations are more important
         # then our previous limit of 0.2 won't be enough to succeed.
-        t = Threshold(; ratio=0.1, weights=reverse!(eweights(20, 0.3)))
+        t = WeightedThreshold(; limit=0.1, weights=reverse!(eweights(20, 0.3)))
         @test_throws ThresholdError validate(a, t)
         @test_throws ThresholdError validate(table, t)
 
-        t = Threshold(; ratio=0.1, weights=reverse!(eweights(5, 0.3)))
+        t = WeightedThreshold(; limit=0.1, weights=reverse!(eweights(5, 0.3)))
         @test_throws ThresholdError validate(m, t; dims=:cols)
         @test_throws ThresholdError validate(aa, t; dims=:cols)
 
@@ -69,8 +69,8 @@
     end
 
     @testset "functional" begin
-        @test_throws ThresholdError Impute.threshold(a; ratio=0.1)
+        @test_throws ThresholdError Impute.threshold(a; limit=0.1)
         # Use isequal because we expect the results to contain missings
-        @test isequal(Impute.threshold(a; ratio=0.8), a)
+        @test isequal(Impute.threshold(a; limit=0.8), a)
     end
 end


### PR DESCRIPTION
Most of the extra LOC are for more tests for the new `WeightedThreshold` and `WeightedSubstitute` types

This PR closes #74, closes #79 and closes #81 

NOTE: This seems to be what Distances.jl does between weighted and non-weighted distance types.