### PR TITLE
Fix Impute path in docs/Manifest.toml

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,13 +9,11 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.version == 'nightly' }}
     strategy:
       fail-fast: false
       matrix:
         version:
           - 1
-          - nightly
         os:
           - ubuntu-latest
         arch:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Impute"
 uuid = "f7bf1975-0170-51b9-8c5f-a992d46b9575"
 authors = ["Invenia Technical Computing"]
-version = "0.6.0"
+version = "0.6.1"
 
 [deps]
 BSON = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"
@@ -29,7 +29,7 @@ IterTools = "1.2, 1.3"
 Missings = "0.4"
 NamedDims = "0.2"
 NearestNeighbors = "0.4"
-StatsBase = "0.32"
+StatsBase = "0.32, 0.33"
 TableOperations = "0.2"
 Tables = "1"
 julia = "1"

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -6,6 +6,12 @@ git-tree-sha1 = "051c95d6836228d120f5f4b984dd5aba1624f716"
 uuid = "621f4979-c628-5d54-868e-fcf4e3e8185c"
 version = "0.5.0"
 
+[[Adapt]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "42c42f2221906892ceb765dbcb1a51deeffd86d7"
+uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+version = "2.3.0"
+
 [[Artifacts]]
 deps = ["Pkg"]
 git-tree-sha1 = "c30985d8821e0cd73870b17b0ed0ce6dc44cb744"
@@ -13,10 +19,10 @@ uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 version = "1.3.0"
 
 [[AxisKeys]]
-deps = ["AbstractFFTs", "IntervalSets", "InvertedIndices", "LazyStack", "LinearAlgebra", "NamedDims", "OffsetArrays", "Statistics", "Tables"]
-git-tree-sha1 = "f3a35fff6784dc24c17fd6351b6b41c4580bcd5a"
+deps = ["AbstractFFTs", "CovarianceEstimation", "IntervalSets", "InvertedIndices", "LazyStack", "LinearAlgebra", "NamedDims", "OffsetArrays", "Statistics", "StatsBase", "Tables"]
+git-tree-sha1 = "07d2dfe4bcd36039bf927238243ed1673032a6bd"
 uuid = "94b1ba4f-4ee9-5380-92f1-94cde586c3c5"
-version = "0.1.6"
+version = "0.1.8"
 
 [[BSON]]
 git-tree-sha1 = "dd36d7cf3d185eeaaf64db902c15174b22f5dafb"
@@ -26,17 +32,17 @@ version = "0.2.6"
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
-[[BinaryProvider]]
-deps = ["Libdl", "Logging", "SHA"]
-git-tree-sha1 = "ecdec412a9abc8db54c0efc5548c64dfce072058"
-uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
-version = "0.5.10"
+[[Bzip2_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "c3598e525718abcc440f69cc6d5f60dda0a1b61e"
+uuid = "6e34b625-4abd-537c-b88f-471c36dfa7a0"
+version = "1.0.6+5"
 
 [[CSV]]
 deps = ["CategoricalArrays", "DataFrames", "Dates", "Mmap", "Parsers", "PooledArrays", "SentinelArrays", "Tables", "Unicode"]
-git-tree-sha1 = "a390152e6850405a48ca51bd7ca33d11a21d6230"
+git-tree-sha1 = "b1f60ea404dc40a76e7f539672ce651079a5a190"
 uuid = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
-version = "0.7.7"
+version = "0.7.10"
 
 [[CategoricalArrays]]
 deps = ["DataAPI", "Future", "JSON", "Missings", "Printf", "Statistics", "StructTypes", "Unicode"]
@@ -44,46 +50,63 @@ git-tree-sha1 = "2ac27f59196a68070e132b25713f9a5bbc5fa0d2"
 uuid = "324d7699-5711-5eae-9e2f-1d82baa6b597"
 version = "0.8.3"
 
+[[ColorSchemes]]
+deps = ["ColorTypes", "Colors", "FixedPointNumbers", "Random", "StaticArrays"]
+git-tree-sha1 = "3141757b5832ee7a0386db87997ee5a23ff20f4d"
+uuid = "35d6a980-a343-548e-a6ea-1d62b119f2f4"
+version = "3.10.2"
+
 [[ColorTypes]]
 deps = ["FixedPointNumbers", "Random"]
-git-tree-sha1 = "b9de8dc6106e09c79f3f776c27c62360d30e5eb8"
+git-tree-sha1 = "4bffea7ed1a9f0f3d1a131bbcd4b925548d75288"
 uuid = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
-version = "0.9.1"
+version = "0.10.9"
 
 [[Colors]]
-deps = ["ColorTypes", "FixedPointNumbers", "InteractiveUtils", "Printf", "Reexport"]
-git-tree-sha1 = "177d8b959d3c103a6d57574c38ee79c81059c31b"
+deps = ["ColorTypes", "FixedPointNumbers", "InteractiveUtils", "Reexport"]
+git-tree-sha1 = "008d6bc68dea6beb6303fdc37188cb557391ebf2"
 uuid = "5ae59095-9a9b-59fe-a467-6f913c188581"
-version = "0.11.2"
+version = "0.12.4"
 
 [[Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "cf03b37436c6bc162e7c8943001568b4cad4bee3"
+git-tree-sha1 = "2724ac91f1334c8e5c10565faad5afeafd1bfc89"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.19.0"
+version = "3.24.0"
 
 [[Contour]]
 deps = ["StaticArrays"]
-git-tree-sha1 = "d05a3a25b762720d40246d5bedf518c9c2614ef5"
+git-tree-sha1 = "9f02045d934dc030edad45944ea80dbd1f0ebea7"
 uuid = "d38c429a-6771-53c6-b99e-75d170b6e991"
-version = "0.5.5"
+version = "0.5.7"
+
+[[CovarianceEstimation]]
+deps = ["LinearAlgebra", "Statistics", "StatsBase"]
+git-tree-sha1 = "85501f0aa96395e944639e3531fe9b0f08393af1"
+uuid = "587fd27a-f159-11e8-2dae-1979310e6154"
+version = "0.2.5"
+
+[[Crayons]]
+git-tree-sha1 = "3f71217b538d7aaee0b69ab47d9b7724ca8afa0d"
+uuid = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
+version = "4.0.4"
 
 [[DataAPI]]
-git-tree-sha1 = "176e23402d80e7743fc26c19c681bfb11246af32"
+git-tree-sha1 = "ad84f52c0b8f05aa20839484dbaf01690b41ff84"
 uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
-version = "1.3.0"
+version = "1.4.0"
 
 [[DataDeps]]
 deps = ["HTTP", "Reexport", "SHA"]
-git-tree-sha1 = "f2be642d7a94e7f0cabcd2106fee4c6715d452d1"
+git-tree-sha1 = "b439b948e3113e3893de985e8c908b034ce4ecf5"
 uuid = "124859b0-ceae-595e-8997-d05f6a7a8dfe"
-version = "0.7.2"
+version = "0.7.4"
 
 [[DataFrames]]
-deps = ["CategoricalArrays", "Compat", "DataAPI", "Future", "InvertedIndices", "IteratorInterfaceExtensions", "Missings", "PooledArrays", "Printf", "REPL", "Reexport", "SortingAlgorithms", "Statistics", "TableTraits", "Tables", "Unicode"]
-git-tree-sha1 = "a7c1c9a6e47a92321bbc9d500dab9b04cc4a6a39"
+deps = ["CategoricalArrays", "Compat", "DataAPI", "Future", "InvertedIndices", "IteratorInterfaceExtensions", "LinearAlgebra", "Markdown", "Missings", "PooledArrays", "PrettyTables", "Printf", "REPL", "Reexport", "SortingAlgorithms", "Statistics", "TableTraits", "Tables", "Unicode"]
+git-tree-sha1 = "20159837c2e5e196793a313cd700b8199fd8f985"
 uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-version = "0.21.7"
+version = "0.22.1"
 
 [[DataStructures]]
 deps = ["InteractiveUtils", "OrderedCollections"]
@@ -121,10 +144,16 @@ uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 version = "0.8.3"
 
 [[Documenter]]
-deps = ["Base64", "DocStringExtensions", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Unicode"]
-git-tree-sha1 = "580155ffaeb175f37dc0bd31ed6c127663efbc60"
+deps = ["Base64", "Dates", "DocStringExtensions", "IOCapture", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Test", "Unicode"]
+git-tree-sha1 = "c01a7e8bcf7a6693444a52a0c5ac8b4e9528600e"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "0.22.6"
+version = "0.26.0"
+
+[[EarCut_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "92d8f9f208637e8d2d28c664051a00569c01493d"
+uuid = "5ae413db-bbd1-5e63-b57d-d24a61df00f5"
+version = "2.1.5+1"
 
 [[EllipsisNotation]]
 git-tree-sha1 = "65dad386e877850e6fce4fc77f60fe75a468ce9d"
@@ -132,31 +161,56 @@ uuid = "da5c29d0-fa7d-589e-88eb-ea29b0a81949"
 version = "0.4.0"
 
 [[FFMPEG]]
-deps = ["BinaryProvider", "Libdl"]
-git-tree-sha1 = "9143266ba77d3313a4cf61d8333a1970e8c5d8b6"
+deps = ["FFMPEG_jll", "x264_jll"]
+git-tree-sha1 = "9a73ffdc375be61b0e4516d83d880b265366fe1f"
 uuid = "c87230d0-a227-11e9-1b43-d7ebe4e7570a"
-version = "0.2.4"
+version = "0.4.0"
+
+[[FFMPEG_jll]]
+deps = ["Artifacts", "Bzip2_jll", "FreeType2_jll", "FriBidi_jll", "JLLWrappers", "LAME_jll", "LibVPX_jll", "Libdl", "Ogg_jll", "OpenSSL_jll", "Opus_jll", "Pkg", "Zlib_jll", "libass_jll", "libfdk_aac_jll", "libvorbis_jll", "x264_jll", "x265_jll"]
+git-tree-sha1 = "3cc57ad0a213808473eafef4845a74766242e05f"
+uuid = "b22a6f82-2f65-5046-a5b2-351ab43fb4e5"
+version = "4.3.1+4"
 
 [[FixedPointNumbers]]
-git-tree-sha1 = "d14a6fa5890ea3a7e5dcab6811114f132fec2b4b"
+deps = ["Statistics"]
+git-tree-sha1 = "335bfdceacc84c5cdf16aadc768aa5ddfc5383cc"
 uuid = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
-version = "0.6.1"
+version = "0.8.4"
+
+[[Formatting]]
+deps = ["Printf"]
+git-tree-sha1 = "8339d61043228fdd3eb658d86c926cb282ae72a8"
+uuid = "59287772-0a20-5a39-b81b-1366585eb4c0"
+version = "0.4.2"
+
+[[FreeType2_jll]]
+deps = ["Artifacts", "Bzip2_jll", "JLLWrappers", "Libdl", "Pkg", "Zlib_jll"]
+git-tree-sha1 = "cbd58c9deb1d304f5a245a0b7eb841a2560cfec6"
+uuid = "d7e528f0-a631-5988-bf34-fe36492bcfd7"
+version = "2.10.1+5"
+
+[[FriBidi_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "0d20aed5b14dd4c9a2453c1b601d08e1149679cc"
+uuid = "559328eb-81f9-559d-9380-de523a88c83c"
+version = "1.0.5+6"
 
 [[Future]]
 deps = ["Random"]
 uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
 
 [[GR]]
-deps = ["Base64", "DelimitedFiles", "LinearAlgebra", "Printf", "Random", "Serialization", "Sockets", "Test"]
-git-tree-sha1 = "c690c2ab22ac9ee323d9966deae61a089362b25c"
+deps = ["Base64", "DelimitedFiles", "LinearAlgebra", "Printf", "Random", "Serialization", "Sockets", "Test", "UUIDs"]
+git-tree-sha1 = "1185d50c5c90ec7c0784af7f8d0d1a600750dc4d"
 uuid = "28b8d3ca-fb5f-59d9-8090-bfdbd6d07a71"
-version = "0.44.0"
+version = "0.49.1"
 
-[[GeometryTypes]]
-deps = ["ColorTypes", "FixedPointNumbers", "LinearAlgebra", "StaticArrays"]
-git-tree-sha1 = "78f0ce9d01993b637a8f28d84537d75dc0ce8eef"
-uuid = "4d00f742-c7ba-57c2-abde-4428a4b178cb"
-version = "0.7.10"
+[[GeometryBasics]]
+deps = ["EarCut_jll", "IterTools", "LinearAlgebra", "StaticArrays", "StructArrays", "Tables"]
+git-tree-sha1 = "5f439f707352a988411d44cbb146fe23674e28b7"
+uuid = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
+version = "0.3.4"
 
 [[Grisu]]
 git-tree-sha1 = "03d381f65183cb2d0af8b3425fde97263ce9a995"
@@ -164,10 +218,16 @@ uuid = "42e2da0e-8278-4e71-bc24-59509adca0fe"
 version = "1.0.0"
 
 [[HTTP]]
-deps = ["Base64", "Dates", "IniFile", "MbedTLS", "Sockets"]
-git-tree-sha1 = "c7ec02c4c6a039a98a15f955462cd7aea5df4508"
+deps = ["Base64", "Dates", "IniFile", "MbedTLS", "Sockets", "URIs"]
+git-tree-sha1 = "504ca74f27377a25ebfd63b1f5e6ec3e9fb14690"
 uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-version = "0.8.19"
+version = "0.9.1"
+
+[[IOCapture]]
+deps = ["Logging"]
+git-tree-sha1 = "377252859f740c217b936cebcd918a44f9b53b59"
+uuid = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
+version = "0.1.1"
 
 [[Impute]]
 deps = ["BSON", "CSV", "DataDeps", "Distances", "IterTools", "LinearAlgebra", "Missings", "NamedDims", "NearestNeighbors", "Random", "Statistics", "StatsBase", "TableOperations", "Tables"]
@@ -213,10 +273,27 @@ uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
 version = "1.1.3"
 
 [[JSON]]
-deps = ["Dates", "Mmap", "Unicode"]
-git-tree-sha1 = "565947e5338efe62a7db0aa8e5de782c623b04cd"
+deps = ["Dates", "Mmap", "Parsers", "Unicode"]
+git-tree-sha1 = "81690084b6198a2e1da36fcfda16eeca9f9f24e4"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-version = "0.20.1"
+version = "0.21.1"
+
+[[LAME_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "df381151e871f41ee86cee4f5f6fd598b8a68826"
+uuid = "c1c5ebd0-6772-5130-a774-d5fcae4a789d"
+version = "3.100.0+3"
+
+[[LaTeXStrings]]
+git-tree-sha1 = "c7aebfecb1a60d59c0fe023a68ec947a208b1e6b"
+uuid = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
+version = "1.2.0"
+
+[[Latexify]]
+deps = ["Formatting", "InteractiveUtils", "LaTeXStrings", "MacroTools", "Markdown", "Printf", "Requires"]
+git-tree-sha1 = "1a8fd0d819f88fd802f54278f02b120cfc4f5755"
+uuid = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
+version = "0.14.6"
 
 [[LazyStack]]
 deps = ["LinearAlgebra", "NamedDims", "OffsetArrays", "Test", "ZygoteRules"]
@@ -227,6 +304,12 @@ version = "0.0.7"
 [[LibGit2]]
 deps = ["Printf"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[LibVPX_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "85fcc80c3052be96619affa2fe2e6d2da3908e11"
+uuid = "dd192d2f-8180-539f-9fb4-cc70b1dcf69a"
+version = "1.9.0+1"
 
 [[Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
@@ -240,9 +323,9 @@ uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [[MacroTools]]
 deps = ["Markdown", "Random"]
-git-tree-sha1 = "f7d2e3f654af75f01ec49be82c231c382214223a"
+git-tree-sha1 = "6a8a2a625ab0dea913aba95c11370589e0239ff0"
 uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
-version = "0.5.5"
+version = "0.5.6"
 
 [[Markdown]]
 deps = ["Base64"]
@@ -250,9 +333,9 @@ uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
 [[MbedTLS]]
 deps = ["Dates", "MbedTLS_jll", "Random", "Sockets"]
-git-tree-sha1 = "426a6978b03a97ceb7ead77775a1da066343ec6e"
+git-tree-sha1 = "1c38e51c3d08ef2278062ebceade0e46cefc96fe"
 uuid = "739be429-bea8-5141-9913-cc70e7f3736d"
-version = "1.0.2"
+version = "1.0.3"
 
 [[MbedTLS_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -275,37 +358,56 @@ version = "0.4.4"
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
 [[NaNMath]]
-git-tree-sha1 = "c84c576296d0e2fbb3fc134d3e09086b3ea617cd"
+git-tree-sha1 = "bfe47e760d60b82b66b61d2d44128b62e3a369fb"
 uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
-version = "0.3.4"
+version = "0.3.5"
 
 [[NamedDims]]
 deps = ["LinearAlgebra", "Pkg", "Requires", "Statistics"]
-git-tree-sha1 = "263f7305bfa5b8b69cd3239ec6a4c037ff96b3df"
+git-tree-sha1 = "ec71dd922fd8008f29741b1358da9254833ef6ca"
 uuid = "356022a1-0364-5f58-8944-0da4b18d706f"
-version = "0.2.28"
+version = "0.2.29"
 
 [[NearestNeighbors]]
 deps = ["Distances", "StaticArrays"]
-git-tree-sha1 = "93107e3cdada73d63245ed8170dcae680f0c8fd8"
+git-tree-sha1 = "9afd724797039125e8e2cc362098f01dab60bc3a"
 uuid = "b8a86587-4115-5ab1-83bc-aa920d37bbce"
-version = "0.4.6"
+version = "0.4.8"
 
 [[OffsetArrays]]
-git-tree-sha1 = "3fdfca8a532507d65f39ff0ad34fe81097a55337"
+deps = ["Adapt"]
+git-tree-sha1 = "45d5e495ab559357aee8cb1dfb8c12b0787d4545"
 uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-version = "1.3.0"
+version = "1.4.1"
+
+[[Ogg_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "a42c0f138b9ebe8b58eba2271c5053773bde52d0"
+uuid = "e7412a2a-1a6e-54c0-be00-318e2571c051"
+version = "1.3.4+2"
+
+[[OpenSSL_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "71bbbc616a1d710879f5a1021bcba65ffba6ce58"
+uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
+version = "1.1.1+6"
+
+[[Opus_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "f9d57f4126c39565e05a2b0264df99f497fc6f37"
+uuid = "91d4177d-7536-5919-b921-800302f37372"
+version = "1.3.1+3"
 
 [[OrderedCollections]]
-git-tree-sha1 = "16c08bf5dba06609fe45e30860092d6fa41fde7b"
+git-tree-sha1 = "cf59cfed2e2c12e8a2ff0a4f1e9b2cd8650da6db"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-version = "1.3.1"
+version = "1.3.2"
 
 [[Parsers]]
 deps = ["Dates"]
-git-tree-sha1 = "6fa4202675c05ba0f8268a6ddf07606350eda3ce"
+git-tree-sha1 = "50c9a9ed8c714945e01cd53a21007ed3865ed714"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "1.0.11"
+version = "1.0.15"
 
 [[Pkg]]
 deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
@@ -313,27 +415,33 @@ uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [[PlotThemes]]
 deps = ["PlotUtils", "Requires", "Statistics"]
-git-tree-sha1 = "d2f3a41081a72815f5c59eacdc8046237a7cbe12"
+git-tree-sha1 = "c6f5ea535551b3b16835134697f0c65d06c94b91"
 uuid = "ccf2f8ad-2431-5c83-bf29-c5338b663b6a"
-version = "0.4.0"
+version = "2.0.0"
 
 [[PlotUtils]]
-deps = ["Colors", "Dates", "Printf", "Random", "Reexport"]
-git-tree-sha1 = "51e742162c97d35f714f9611619db6975e19384b"
+deps = ["ColorSchemes", "Colors", "Dates", "Printf", "Random", "Reexport", "Statistics"]
+git-tree-sha1 = "6a59c282058f46967069972d74526a68d27a9012"
 uuid = "995b91a9-d308-5afd-9ec6-746e21dbc043"
-version = "0.6.5"
+version = "1.0.8"
 
 [[Plots]]
-deps = ["Base64", "Contour", "Dates", "FFMPEG", "FixedPointNumbers", "GR", "GeometryTypes", "JSON", "LinearAlgebra", "Measures", "NaNMath", "Pkg", "PlotThemes", "PlotUtils", "Printf", "REPL", "Random", "RecipesBase", "Reexport", "Requires", "Showoff", "SparseArrays", "Statistics", "StatsBase", "UUIDs"]
-git-tree-sha1 = "11c75a31269c1c64790e7cb910346f64cd4440c1"
+deps = ["Base64", "Contour", "Dates", "FFMPEG", "FixedPointNumbers", "GR", "GeometryBasics", "JSON", "Latexify", "LinearAlgebra", "Measures", "NaNMath", "PlotThemes", "PlotUtils", "Printf", "REPL", "Random", "RecipesBase", "RecipesPipeline", "Reexport", "Requires", "Scratch", "Showoff", "SparseArrays", "Statistics", "StatsBase", "UUIDs"]
+git-tree-sha1 = "173c7250ccd7c98615b04c669eb13fa7fab494b0"
 uuid = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
-version = "0.27.1"
+version = "1.9.1"
 
 [[PooledArrays]]
 deps = ["DataAPI"]
 git-tree-sha1 = "b1333d4eced1826e15adbdf01a4ecaccca9d353c"
 uuid = "2dfb63ee-cc39-5dd5-95bd-886bf059d720"
 version = "0.5.3"
+
+[[PrettyTables]]
+deps = ["Crayons", "Formatting", "Markdown", "Reexport", "Tables"]
+git-tree-sha1 = "237170206bf38a66fee4d845f4ae57f63788eeb0"
+uuid = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
+version = "0.10.1"
 
 [[Printf]]
 deps = ["Unicode"]
@@ -348,9 +456,15 @@ deps = ["Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [[RecipesBase]]
-git-tree-sha1 = "7bdce29bc9b2f5660a6e5e64d64d91ec941f6aa2"
+git-tree-sha1 = "b3fb709f3c97bfc6e948be68beeecb55a0b340ae"
 uuid = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
-version = "0.7.0"
+version = "1.1.1"
+
+[[RecipesPipeline]]
+deps = ["Dates", "NaNMath", "PlotUtils", "RecipesBase"]
+git-tree-sha1 = "9ea2f5bf1b26918b16e9f885bb8e05206bfc2144"
+uuid = "01d81517-befc-4cb6-b9ec-a95719d0359c"
+version = "0.2.1"
 
 [[Reexport]]
 deps = ["Pkg"]
@@ -359,13 +473,19 @@ uuid = "189a3867-3050-52da-a836-e630ba90ab69"
 version = "0.2.0"
 
 [[Requires]]
-deps = ["Test"]
-git-tree-sha1 = "f6fbf4ba64d295e146e49e021207993b6b48c7d1"
+deps = ["UUIDs"]
+git-tree-sha1 = "e05c53ebc86933601d36212a93b39144a2733493"
 uuid = "ae029012-a4dd-5104-9daa-d747884805df"
-version = "0.5.2"
+version = "1.1.1"
 
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Scratch]]
+deps = ["Dates"]
+git-tree-sha1 = "ad4b278adb62d185bbcb6864dc24959ab0627bf6"
+uuid = "6c6a2e73-6563-6170-7368-637461726353"
+version = "1.0.3"
 
 [[SentinelArrays]]
 deps = ["Dates", "Random"]
@@ -401,9 +521,9 @@ uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [[StaticArrays]]
 deps = ["LinearAlgebra", "Random", "Statistics"]
-git-tree-sha1 = "016d1e1a00fabc556473b07161da3d39726ded35"
+git-tree-sha1 = "9da72ed50e94dbff92036da395275ed114e04d49"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "0.12.4"
+version = "1.0.1"
 
 [[Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]
@@ -415,11 +535,17 @@ git-tree-sha1 = "19bfcb46245f69ff4013b3df3b977a289852c3a1"
 uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 version = "0.32.2"
 
+[[StructArrays]]
+deps = ["Adapt", "DataAPI", "Tables"]
+git-tree-sha1 = "8099ed9fb90b6e754d6ba8c6ed8670f010eadca0"
+uuid = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
+version = "0.4.4"
+
 [[StructTypes]]
 deps = ["Dates", "UUIDs"]
-git-tree-sha1 = "1ed04f622a39d2e5a6747c3a70be040c00333933"
+git-tree-sha1 = "d94235fcdc4a09649f263365c5f7e4ed4ba6ed34"
 uuid = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
-version = "1.1.0"
+version = "1.2.1"
 
 [[TableOperations]]
 deps = ["Tables", "Test"]
@@ -435,13 +561,18 @@ version = "1.0.0"
 
 [[Tables]]
 deps = ["DataAPI", "DataValueInterfaces", "IteratorInterfaceExtensions", "LinearAlgebra", "TableTraits", "Test"]
-git-tree-sha1 = "24a584cf65e2cfabdadc21694fb69d2e74c82b44"
+git-tree-sha1 = "240d19b8762006ff04b967bdd833269ad642d550"
 uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
-version = "1.1.0"
+version = "1.2.2"
 
 [[Test]]
 deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[URIs]]
+git-tree-sha1 = "bc331715463c41d601cf8bfd38ca70a490af5c5b"
+uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
+version = "1.1.0"
 
 [[UUIDs]]
 deps = ["Random", "SHA"]
@@ -450,8 +581,44 @@ uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 [[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
+[[Zlib_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "320228915c8debb12cb434c59057290f0834dbf6"
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+version = "1.2.11+18"
+
 [[ZygoteRules]]
 deps = ["MacroTools"]
 git-tree-sha1 = "b3b4882cc9accf6731a08cc39543fbc6b669dca8"
 uuid = "700de1a5-db45-46bc-99cf-38207098b444"
 version = "0.2.0"
+
+[[libass_jll]]
+deps = ["Artifacts", "Bzip2_jll", "FreeType2_jll", "FriBidi_jll", "JLLWrappers", "Libdl", "Pkg", "Zlib_jll"]
+git-tree-sha1 = "acc685bcf777b2202a904cdcb49ad34c2fa1880c"
+uuid = "0ac62f75-1d6f-5e53-bd7c-93b484bb37c0"
+version = "0.14.0+4"
+
+[[libfdk_aac_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "7a5780a0d9c6864184b3a2eeeb833a0c871f00ab"
+uuid = "f638f0a6-7fb0-5443-88ba-1cc74229b280"
+version = "0.1.6+4"
+
+[[libvorbis_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Ogg_jll", "Pkg"]
+git-tree-sha1 = "fa14ac25af7a4b8a7f61b287a124df7aab601bcd"
+uuid = "f27f6e37-5d2b-51aa-960f-b287f2bc3b7a"
+version = "1.3.6+6"
+
+[[x264_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "d713c1ce4deac133e3334ee12f4adff07f81778f"
+uuid = "1270edf5-f2f9-52d2-97e9-ab00b5d0237a"
+version = "2020.7.14+2"
+
+[[x265_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "487da2f8f2f0c8ee0e83f39d13037d6bbf0a45ab"
+uuid = "dfaa095f-4041-5dcd-9319-2fabd8486b76"
+version = "3.0.0+3"

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -6,6 +6,12 @@ git-tree-sha1 = "051c95d6836228d120f5f4b984dd5aba1624f716"
 uuid = "621f4979-c628-5d54-868e-fcf4e3e8185c"
 version = "0.5.0"
 
+[[Artifacts]]
+deps = ["Pkg"]
+git-tree-sha1 = "c30985d8821e0cd73870b17b0ed0ce6dc44cb744"
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+version = "1.3.0"
+
 [[AxisKeys]]
 deps = ["AbstractFFTs", "IntervalSets", "InvertedIndices", "LazyStack", "LinearAlgebra", "NamedDims", "OffsetArrays", "Statistics", "Tables"]
 git-tree-sha1 = "f3a35fff6784dc24c17fd6351b6b41c4580bcd5a"
@@ -165,7 +171,7 @@ version = "0.8.19"
 
 [[Impute]]
 deps = ["BSON", "CSV", "DataDeps", "Distances", "IterTools", "LinearAlgebra", "Missings", "NamedDims", "NearestNeighbors", "Random", "Statistics", "StatsBase", "TableOperations", "Tables"]
-path = "/Users/rory/repos/invenia/Impute.jl"
+path = ".."
 uuid = "f7bf1975-0170-51b9-8c5f-a992d46b9575"
 version = "0.6.0"
 
@@ -200,6 +206,11 @@ version = "1.3.0"
 git-tree-sha1 = "a3f24677c21f5bbe9d2a714f95dcd58337fb2856"
 uuid = "82899510-4779-5014-852e-03e436cf321d"
 version = "1.0.0"
+
+[[JLLWrappers]]
+git-tree-sha1 = "c70593677bbf2c3ccab4f7500d0f4dacfff7b75c"
+uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+version = "1.1.3"
 
 [[JSON]]
 deps = ["Dates", "Mmap", "Unicode"]
@@ -244,10 +255,10 @@ uuid = "739be429-bea8-5141-9913-cc70e7f3736d"
 version = "1.0.2"
 
 [[MbedTLS_jll]]
-deps = ["Libdl", "Pkg"]
-git-tree-sha1 = "c0b1286883cac4e2b617539de41111e0776d02e8"
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "0eef589dd1c26a3ac9d753fe1a8bcad63f956fa6"
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.16.8+0"
+version = "2.16.8+1"
 
 [[Measures]]
 git-tree-sha1 = "e498ddeee6f9fdb4551ce855a46f54dbd900245f"

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -109,10 +109,10 @@ uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 version = "0.22.1"
 
 [[DataStructures]]
-deps = ["InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "88d48e133e6d3dd68183309877eac74393daa7eb"
+deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
+git-tree-sha1 = "fb0aa371da91c1ff9dc7fbed6122d3e411420b9c"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.17.20"
+version = "0.18.8"
 
 [[DataValueInterfaces]]
 git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
@@ -233,7 +233,7 @@ version = "0.1.1"
 deps = ["BSON", "CSV", "DataDeps", "Distances", "IterTools", "LinearAlgebra", "Missings", "NamedDims", "NearestNeighbors", "Random", "Statistics", "StatsBase", "TableOperations", "Tables"]
 path = ".."
 uuid = "f7bf1975-0170-51b9-8c5f-a992d46b9575"
-version = "0.6.0"
+version = "0.6.1"
 
 [[IniFile]]
 deps = ["Test"]
@@ -531,9 +531,9 @@ uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [[StatsBase]]
 deps = ["DataAPI", "DataStructures", "LinearAlgebra", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics"]
-git-tree-sha1 = "19bfcb46245f69ff4013b3df3b977a289852c3a1"
+git-tree-sha1 = "7bab7d4eb46b225b35179632852b595a3162cb61"
 uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
-version = "0.32.2"
+version = "0.33.2"
 
 [[StructArrays]]
 deps = ["Adapt", "DataAPI", "Tables"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -10,5 +10,5 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-DataFrames = ">= 0.21"
-Documenter = "~0.22"
+DataFrames = "0.22"
+Documenter = "0.26"

--- a/src/functional.jl
+++ b/src/functional.jl
@@ -245,28 +245,29 @@ containing `missing`s.
 julia> using DataFrames; using Impute: Impute
 
 
+
 julia> df = DataFrame(:a => [1.0, 2.0, missing, missing, 5.0], :b => [1.1, 2.2, 3.3, missing, 5.5])
 5×2 DataFrame
-│ Row │ a        │ b        │
-│     │ Float64? │ Float64? │
-├─────┼──────────┼──────────┤
-│ 1   │ 1.0      │ 1.1      │
-│ 2   │ 2.0      │ 2.2      │
-│ 3   │ missing  │ 3.3      │
-│ 4   │ missing  │ missing  │
-│ 5   │ 5.0      │ 5.5      │
+ Row │ a          b
+     │ Float64?   Float64?
+─────┼──────────────────────
+   1 │       1.0        1.1
+   2 │       2.0        2.2
+   3 │ missing          3.3
+   4 │ missing    missing
+   5 │       5.0        5.5
 
 julia> Impute.filter(df; dims=:cols)
 0×0 DataFrame
 
 julia> Impute.filter(df; dims=:rows)
 3×2 DataFrame
-│ Row │ a       │ b       │
-│     │ Float64 │ Float64 │
-├─────┼─────────┼─────────┤
-│ 1   │ 1.0     │ 1.1     │
-│ 2   │ 2.0     │ 2.2     │
-│ 3   │ 5.0     │ 5.5     │
+ Row │ a        b
+     │ Float64  Float64
+─────┼──────────────────
+   1 │     1.0      1.1
+   2 │     2.0      2.2
+   3 │     5.0      5.5
 ```
 """ filter
 
@@ -280,27 +281,28 @@ See [Interpolate](@ref) for details.
 ```jldoctest
 julia> using DataFrames; using Impute: Impute
 
+
 julia> df = DataFrame(:a => [1.0, 2.0, missing, missing, 5.0], :b => [1.1, 2.2, 3.3, missing, 5.5])
 5×2 DataFrame
-│ Row │ a        │ b        │
-│     │ Float64? │ Float64? │
-├─────┼──────────┼──────────┤
-│ 1   │ 1.0      │ 1.1      │
-│ 2   │ 2.0      │ 2.2      │
-│ 3   │ missing  │ 3.3      │
-│ 4   │ missing  │ missing  │
-│ 5   │ 5.0      │ 5.5      │
+ Row │ a          b
+     │ Float64?   Float64?
+─────┼──────────────────────
+   1 │       1.0        1.1
+   2 │       2.0        2.2
+   3 │ missing          3.3
+   4 │ missing    missing
+   5 │       5.0        5.5
 
 julia> Impute.interp(df)
 5×2 DataFrame
-│ Row │ a        │ b        │
-│     │ Float64? │ Float64? │
-├─────┼──────────┼──────────┤
-│ 1   │ 1.0      │ 1.1      │
-│ 2   │ 2.0      │ 2.2      │
-│ 3   │ 3.0      │ 3.3      │
-│ 4   │ 4.0      │ 4.4      │
-│ 5   │ 5.0      │ 5.5      │
+ Row │ a         b
+     │ Float64?  Float64?
+─────┼────────────────────
+   1 │      1.0       1.1
+   2 │      2.0       2.2
+   3 │      3.0       3.3
+   4 │      4.0       4.4
+   5 │      5.0       5.5
 ```
 """ interp
 
@@ -349,27 +351,28 @@ observation. See [LOCF](@ref) for details.
 ```jldoctest
 julia> using DataFrames; using Impute: Impute
 
+
 julia> df = DataFrame(:a => [1.0, 2.0, missing, missing, 5.0], :b => [1.1, 2.2, 3.3, missing, 5.5])
 5×2 DataFrame
-│ Row │ a        │ b        │
-│     │ Float64? │ Float64? │
-├─────┼──────────┼──────────┤
-│ 1   │ 1.0      │ 1.1      │
-│ 2   │ 2.0      │ 2.2      │
-│ 3   │ missing  │ 3.3      │
-│ 4   │ missing  │ missing  │
-│ 5   │ 5.0      │ 5.5      │
+ Row │ a          b
+     │ Float64?   Float64?
+─────┼──────────────────────
+   1 │       1.0        1.1
+   2 │       2.0        2.2
+   3 │ missing          3.3
+   4 │ missing    missing
+   5 │       5.0        5.5
 
 julia> Impute.locf(df)
 5×2 DataFrame
-│ Row │ a        │ b        │
-│     │ Float64? │ Float64? │
-├─────┼──────────┼──────────┤
-│ 1   │ 1.0      │ 1.1      │
-│ 2   │ 2.0      │ 2.2      │
-│ 3   │ 2.0      │ 3.3      │
-│ 4   │ 2.0      │ 3.3      │
-│ 5   │ 5.0      │ 5.5      │
+ Row │ a         b
+     │ Float64?  Float64?
+─────┼────────────────────
+   1 │      1.0       1.1
+   2 │      2.0       2.2
+   3 │      2.0       3.3
+   4 │      2.0       3.3
+   5 │      5.0       5.5
 ```
 """ locf
 
@@ -383,27 +386,28 @@ observation. See [LOCF](@ref) for details.
 ```jldoctest
 julia> using DataFrames; using Impute: Impute
 
+
 julia> df = DataFrame(:a => [1.0, 2.0, missing, missing, 5.0], :b => [1.1, 2.2, 3.3, missing, 5.5])
 5×2 DataFrame
-│ Row │ a        │ b        │
-│     │ Float64? │ Float64? │
-├─────┼──────────┼──────────┤
-│ 1   │ 1.0      │ 1.1      │
-│ 2   │ 2.0      │ 2.2      │
-│ 3   │ missing  │ 3.3      │
-│ 4   │ missing  │ missing  │
-│ 5   │ 5.0      │ 5.5      │
+ Row │ a          b
+     │ Float64?   Float64?
+─────┼──────────────────────
+   1 │       1.0        1.1
+   2 │       2.0        2.2
+   3 │ missing          3.3
+   4 │ missing    missing
+   5 │       5.0        5.5
 
 julia> Impute.nocb(df)
 5×2 DataFrame
-│ Row │ a        │ b        │
-│     │ Float64? │ Float64? │
-├─────┼──────────┼──────────┤
-│ 1   │ 1.0      │ 1.1      │
-│ 2   │ 2.0      │ 2.2      │
-│ 3   │ 5.0      │ 3.3      │
-│ 4   │ 5.0      │ 5.5      │
-│ 5   │ 5.0      │ 5.5      │
+ Row │ a         b
+     │ Float64?  Float64?
+─────┼────────────────────
+   1 │      1.0       1.1
+   2 │      2.0       2.2
+   3 │      5.0       3.3
+   4 │      5.0       5.5
+   5 │      5.0       5.5
 ```
 """ nocb
 
@@ -454,31 +458,32 @@ DeclareMissings (or replace) various missing data representations with `missing`
 ```jldoctest
 julia> using DataFrames, Impute
 
+
 julia> df = DataFrame(
            :a => [1.1, 2.2, NaN, NaN, 5.5],
            :b => [1, 2, 3, -9999, 5],
            :c => ["v", "w", "x", "y", "NULL"],
        )
 5×3 DataFrame
-│ Row │ a       │ b     │ c      │
-│     │ Float64 │ Int64 │ String │
-├─────┼─────────┼───────┼────────┤
-│ 1   │ 1.1     │ 1     │ v      │
-│ 2   │ 2.2     │ 2     │ w      │
-│ 3   │ NaN     │ 3     │ x      │
-│ 4   │ NaN     │ -9999 │ y      │
-│ 5   │ 5.5     │ 5     │ NULL   │
+ Row │ a        b      c
+     │ Float64  Int64  String
+─────┼────────────────────────
+   1 │     1.1      1  v
+   2 │     2.2      2  w
+   3 │   NaN        3  x
+   4 │   NaN    -9999  y
+   5 │     5.5      5  NULL
 
 julia> Impute.declaremissings(df; values=(NaN, -9999, "NULL"))
 5×3 DataFrame
-│ Row │ a        │ b       │ c       │
-│     │ Float64? │ Int64?  │ String? │
-├─────┼──────────┼─────────┼─────────┤
-│ 1   │ 1.1      │ 1       │ v       │
-│ 2   │ 2.2      │ 2       │ w       │
-│ 3   │ missing  │ 3       │ x       │
-│ 4   │ missing  │ missing │ y       │
-│ 5   │ 5.5      │ 5       │ missing │
+ Row │ a          b        c
+     │ Float64?   Int64?   String?
+─────┼─────────────────────────────
+   1 │       1.1        1  v
+   2 │       2.2        2  w
+   3 │ missing          3  x
+   4 │ missing    missing  y
+   5 │       5.5        5  missing
 ```
 """ declaremissings
 
@@ -502,37 +507,38 @@ See [Substitute](@ref) for details on substitution rules defined in `defaultstat
 ```jldoctest
 julia> using DataFrames, Impute
 
+
 julia> df = DataFrame(
                   :a => [8.9, 2.2, missing, missing, 1.3, 6.2, 3.7, 4.8],
                   :b => [2, 6, 3, missing, 7, 1, 9, missing],
                   :c => [true, false, true, true, false, missing, false, true],
               )
 8×3 DataFrame
-│ Row │ a        │ b       │ c       │
-│     │ Float64? │ Int64?  │ Bool?   │
-├─────┼──────────┼─────────┼─────────┤
-│ 1   │ 8.9      │ 2       │ 1       │
-│ 2   │ 2.2      │ 6       │ 0       │
-│ 3   │ missing  │ 3       │ 1       │
-│ 4   │ missing  │ missing │ 1       │
-│ 5   │ 1.3      │ 7       │ 0       │
-│ 6   │ 6.2      │ 1       │ missing │
-│ 7   │ 3.7      │ 9       │ 0       │
-│ 8   │ 4.8      │ missing │ 1       │
+ Row │ a          b        c
+     │ Float64?   Int64?   Bool?
+─────┼─────────────────────────────
+   1 │       8.9        2     true
+   2 │       2.2        6    false
+   3 │ missing          3     true
+   4 │ missing    missing     true
+   5 │       1.3        7    false
+   6 │       6.2        1  missing
+   7 │       3.7        9    false
+   8 │       4.8  missing     true
 
 julia> Impute.substitute(df)
 8×3 DataFrame
-│ Row │ a        │ b      │ c     │
-│     │ Float64? │ Int64? │ Bool? │
-├─────┼──────────┼────────┼───────┤
-│ 1   │ 8.9      │ 2      │ 1     │
-│ 2   │ 2.2      │ 6      │ 0     │
-│ 3   │ 4.25     │ 3      │ 1     │
-│ 4   │ 4.25     │ 4      │ 1     │
-│ 5   │ 1.3      │ 7      │ 0     │
-│ 6   │ 6.2      │ 1      │ 1     │
-│ 7   │ 3.7      │ 9      │ 0     │
-│ 8   │ 4.8      │ 4      │ 1     │
+ Row │ a         b       c
+     │ Float64?  Int64?  Bool?
+─────┼─────────────────────────
+   1 │     8.9        2   true
+   2 │     2.2        6  false
+   3 │     4.25       3   true
+   4 │     4.25       4   true
+   5 │     1.3        7  false
+   6 │     6.2        1   true
+   7 │     3.7        9  false
+   8 │     4.8        4   true
 ```
 """ substitute
 

--- a/src/imputors.jl
+++ b/src/imputors.jl
@@ -195,27 +195,28 @@ if this is not the desired behaviour custom imputor methods should overload this
 ```jldoctest
 julia> using DataFrames; using Impute: Interpolate, impute
 
+
 julia> df = DataFrame(:a => [1.0, 2.0, missing, missing, 5.0], :b => [1.1, 2.2, 3.3, missing, 5.5])
 5×2 DataFrame
-│ Row │ a        │ b        │
-│     │ Float64? │ Float64? │
-├─────┼──────────┼──────────┤
-│ 1   │ 1.0      │ 1.1      │
-│ 2   │ 2.0      │ 2.2      │
-│ 3   │ missing  │ 3.3      │
-│ 4   │ missing  │ missing  │
-│ 5   │ 5.0      │ 5.5      │
+ Row │ a          b
+     │ Float64?   Float64?
+─────┼──────────────────────
+   1 │       1.0        1.1
+   2 │       2.0        2.2
+   3 │ missing          3.3
+   4 │ missing    missing
+   5 │       5.0        5.5
 
 julia> impute(df, Interpolate())
 5×2 DataFrame
-│ Row │ a        │ b        │
-│     │ Float64? │ Float64? │
-├─────┼──────────┼──────────┤
-│ 1   │ 1.0      │ 1.1      │
-│ 2   │ 2.0      │ 2.2      │
-│ 3   │ 3.0      │ 3.3      │
-│ 4   │ 4.0      │ 4.4      │
-│ 5   │ 5.0      │ 5.5      │
+ Row │ a         b
+     │ Float64?  Float64?
+─────┼────────────────────
+   1 │      1.0       1.1
+   2 │      2.0       2.2
+   3 │      3.0       3.3
+   4 │      4.0       4.4
+   5 │      5.0       5.5
 ```
 """
 function impute!(table::T, imp::Imputor; cols=nothing)::T where T

--- a/src/validators.jl
+++ b/src/validators.jl
@@ -74,16 +74,17 @@ the minimum internal `_validate` call requirements.
 ```jldoctest
 julia> using DataFrames, Test; using Impute: Threshold, ThresholdError, validate
 
+
 julia> df = DataFrame(:a => [1.0, 2.0, missing, missing, 5.0], :b => [1.1, 2.2, 3.3, missing, 5.5])
 5×2 DataFrame
-│ Row │ a        │ b        │
-│     │ Float64? │ Float64? │
-├─────┼──────────┼──────────┤
-│ 1   │ 1.0      │ 1.1      │
-│ 2   │ 2.0      │ 2.2      │
-│ 3   │ missing  │ 3.3      │
-│ 4   │ missing  │ missing  │
-│ 5   │ 5.0      │ 5.5      │
+ Row │ a          b
+     │ Float64?   Float64?
+─────┼──────────────────────
+   1 │       1.0        1.1
+   2 │       2.0        2.2
+   3 │ missing          3.3
+   4 │ missing    missing
+   5 │       5.0        5.5
 
 julia> @test_throws ThresholdError validate(df, Threshold())
 Test Passed


### PR DESCRIPTION
NOTE: The reason we didn't notice this before was that that Manifest appears to have been cached? Seems like it started failing for more recent build because that cache was no longer around so it started looking for Impute.jl at `/Users/rory/repos/invenia/Impute.jl`

Closes #96 