### PR TITLE
Fix the CI Schedule once more

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,7 +2,7 @@ name: CI
 # Run on master, tags, or any pull request
 on:
   schedule:
-    - cron: '0 2 * * *'  # Daily at 2 AM UTC (8 PM CST)
+    - cron: '0 * * * *'  # Run every hour to test the slack, then rever to -> Daily at 2 AM UTC (8 PM CST)
   push:
     branches: [master]
     tags: ["*"]

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -65,7 +65,7 @@ jobs:
     name: Notify Slack Failure
     needs: test
     runs-on: ubuntu-latest
-    if: github.event_name == 'schedule'
+    if: always() && github.event_name == 'schedule'
     steps:
       - uses: technote-space/workflow-conclusion-action@v2
       - uses: voxmedia/github-action-slack-notify-build@v1


### PR DESCRIPTION
Ok, so after doing more research, I think the issue is that the slack job defines `needs: test` which says "Only run this once 'test' is done", and it also defines `if: github.event_name == 'schedule'` which says "Only run this when the CI is triggered by the schedule".

The problem is that if `test` fails then the `needs` criteria fails and the job is skipped. If you set the `if` to `if: always()` it will run after `test` regardless if `test` passed or failed. So if we add that to the if criteria, we should get the slack job to run only on the schedule regardless if the tests passed or not. (https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#example-not-requiring-dependent-jobs-to-be-successful)

p.s. sorry for so many PR's @rofinn 