### PR TITLE
Fixes compatibility for tests running against Juliav1.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Impute"
 uuid = "f7bf1975-0170-51b9-8c5f-a992d46b9575"
 authors = ["Invenia Technical Computing"]
-version = "0.6.9"
+version = "0.6.8"
 
 [deps]
 BSON = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Impute"
 uuid = "f7bf1975-0170-51b9-8c5f-a992d46b9575"
 authors = ["Invenia Technical Computing"]
-version = "0.6.8"
+version = "0.6.9"
 
 [deps]
 BSON = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"

--- a/test/imputors/knn.jl
+++ b/test/imputors/knn.jl
@@ -66,8 +66,8 @@
             knn_imputed = impute(copy(X), Impute.KNN(; k=4); dims=:cols)
             mean_imputed = impute(copy(X), Substitute(); dims=:cols)
 
-            knn_nrmsd = ((i - 1) * knn_nrmsd + nrmsd(data', knn_imputed)) / i
-            mean_nrmsd = ((i - 1) * mean_nrmsd + nrmsd(data', mean_imputed)) / i
+            knn_nrmsd = ((i - 1) * knn_nrmsd + nrmsd(knn_imputed, data')) / i
+            mean_nrmsd = ((i - 1) * mean_nrmsd + nrmsd(mean_imputed, data')) / i
         end
 
         # @show knn_nrmsd mean_nrmsd


### PR DESCRIPTION
When running `Impute.jl` tests against Julia1.8, we run into a problem when calling the `nrmsd()` function [here](https://github.com/invenia/Impute.jl/blob/master/test/imputors/knn.jl#L69) (from `Distances.jl`, function found [here](https://github.com/JuliaStats/Distances.jl/blob/master/src/metrics.jl#L652)).

There error we get is as follows:

![Screen Shot 2022-10-03 at 4 01 26 PM](https://user-images.githubusercontent.com/16655186/193681720-bfacc975-49c7-4704-b333-3f7cc4979246.png)

Since there were some changes/refactoring to the `extrema()` function, it created a `MethodError`, where it couldn't match the `adjoint()` method with what we passed in (`adjoint(data)` from within the failing test).

Flipping the two around fixes the tests, but not the root of the problem. I'm not sure if this is the correct solution, or if I have to report this as an issue with `JuliaLang` itself. I know a bunch of other stuff changed around `mapping`, so maybe this isn't a problem here, but a new limitation with the language itself.

Happy to hear some feedback about this :)