### PR TITLE
adapt Data match tests to changed behaviour of Combinatics.combinations

### DIFF
--- a/test/imputors/knn.jl
+++ b/test/imputors/knn.jl
@@ -43,7 +43,7 @@
     @testset "Data match" begin
         data = mapreduce(hcat, 1:1000) do i
             seeds = [sin(i), cos(i), tan(i), atan(i)]
-            mapreduce(vcat, combinations(seeds)) do args
+            mapreduce(vcat, Iterators.filter(!isempty, combinations(seeds))) do args
                 [
                     +(args...),
                     *(args...),

--- a/test/imputors/svd.jl
+++ b/test/imputors/svd.jl
@@ -66,7 +66,7 @@
     @testset "Data match" begin
         data = mapreduce(hcat, 1:1000) do i
             seeds = [sin(i), cos(i), tan(i), atan(i)]
-            mapreduce(vcat, combinations(seeds)) do args
+            mapreduce(vcat, Iterators.filter(!isempty, combinations(seeds))) do args
                 [
                     +(args...),
                     *(args...),


### PR DESCRIPTION
Currently tests fail in two places due to changed behaviour of Combinatorics.combinations, which used to return only non-empty combinations, but now also returns an empty array.
This PR filters the empty combination to restore previous behaviour.